### PR TITLE
Add pluggable storage service interface

### DIFF
--- a/src/main/java/in/lazygod/service/StorageService.java
+++ b/src/main/java/in/lazygod/service/StorageService.java
@@ -1,0 +1,44 @@
+package in.lazygod.service;
+
+import org.springframework.core.io.Resource;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+/**
+ * General contract for file storage operations. Implementations may store
+ * files on local disk, S3 or any remote server.
+ */
+public interface StorageService {
+
+    /**
+     * Upload a file to a specific location.
+     *
+     * @param file the file to store
+     * @param destinationPath relative destination path inside the storage
+     */
+    void upload(MultipartFile file, String destinationPath) throws IOException;
+
+    /**
+     * Retrieve a file from storage.
+     *
+     * @param storagePath relative path to the file in storage
+     * @return the file as a {@link Resource}
+     */
+    Resource download(String storagePath) throws IOException;
+
+    /**
+     * Delete a file from storage.
+     *
+     * @param storagePath relative path to the file in storage
+     */
+    void delete(String storagePath) throws IOException;
+
+    /**
+     * Check if a given file exists in storage.
+     *
+     * @param storagePath relative path to the file in storage
+     * @return true if the file exists
+     */
+    boolean exists(String storagePath) throws IOException;
+}

--- a/src/main/java/in/lazygod/service/impl/LocalStorageService.java
+++ b/src/main/java/in/lazygod/service/impl/LocalStorageService.java
@@ -1,0 +1,46 @@
+package in.lazygod.service.impl;
+
+import in.lazygod.service.StorageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+@Service
+public class LocalStorageService implements StorageService {
+
+    /**
+     * Base location on the local filesystem where files will be stored.
+     */
+    @Value("${storage.local.base-path}")
+    private Path basePath;
+
+    @Override
+    public void upload(MultipartFile file, String destinationPath) throws IOException {
+        Path target = basePath.resolve(destinationPath).normalize();
+        Files.createDirectories(target.getParent());
+        Files.copy(file.getInputStream(), target, StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    @Override
+    public Resource download(String storagePath) throws IOException {
+        Path filePath = basePath.resolve(storagePath).normalize();
+        return new UrlResource(filePath.toUri());
+    }
+
+    @Override
+    public void delete(String storagePath) throws IOException {
+        Files.deleteIfExists(basePath.resolve(storagePath).normalize());
+    }
+
+    @Override
+    public boolean exists(String storagePath) {
+        return Files.exists(basePath.resolve(storagePath).normalize());
+    }
+}

--- a/src/main/java/in/lazygod/service/impl/S3StorageService.java
+++ b/src/main/java/in/lazygod/service/impl/S3StorageService.java
@@ -1,0 +1,37 @@
+package in.lazygod.service.impl;
+
+import in.lazygod.service.StorageService;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+/**
+ * Placeholder implementation for S3 storage. The actual AWS S3 integration
+ * can be provided by wiring the AWS SDK and injecting an AmazonS3 client.
+ */
+@Service
+public class S3StorageService implements StorageService {
+
+    @Override
+    public void upload(MultipartFile file, String destinationPath) throws IOException {
+        // TODO: integrate AWS SDK or other S3 compatible client
+        throw new UnsupportedOperationException("S3 upload not implemented");
+    }
+
+    @Override
+    public Resource download(String storagePath) throws IOException {
+        throw new UnsupportedOperationException("S3 download not implemented");
+    }
+
+    @Override
+    public void delete(String storagePath) throws IOException {
+        throw new UnsupportedOperationException("S3 delete not implemented");
+    }
+
+    @Override
+    public boolean exists(String storagePath) throws IOException {
+        throw new UnsupportedOperationException("S3 exists not implemented");
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,7 @@ logging:
   level:
     root: INFO
     com.example.filemanager: DEBUG
+
+storage:
+  local:
+    base-path: files


### PR DESCRIPTION
## Summary
- create new `StorageService` interface for file operations
- implement `LocalStorageService` for simple filesystem storage
- add placeholder `S3StorageService` for future S3 support
- configure `storage.local.base-path` in application.yml

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68842019e5d8833083229e0eb3daa442