### PR TITLE
Switch to String-based Snowflake IDs

### DIFF
--- a/src/main/java/in/lazygod/controller/AuthController.java
+++ b/src/main/java/in/lazygod/controller/AuthController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
-import java.util.UUID;
+import in.lazygod.util.SnowflakeIdGenerator;
 
 @RestController
 @RequestMapping("/auth")
@@ -27,6 +27,7 @@ public class AuthController {
     private final JwtUtil jwtUtil;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final SnowflakeIdGenerator idGenerator;
 
     @PostMapping("/login")
     public ResponseEntity<AuthResponse> login(@RequestBody AuthRequest request) {
@@ -60,7 +61,7 @@ public class AuthController {
         }
 
         User user = User.builder()
-                .userId(UUID.randomUUID())
+                .userId(idGenerator.nextId())
                 .username(request.getUsername())
                 .fullName(request.getFullName())
                 .email(request.getEmail()) // placeholder

--- a/src/main/java/in/lazygod/models/File.java
+++ b/src/main/java/in/lazygod/models/File.java
@@ -11,7 +11,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.UUID;
+
 
 @Entity
 @Data
@@ -20,14 +20,14 @@ import java.util.UUID;
 @Builder
 public class File {
     @Id
-    private UUID fileId;
+    private String fileId;
 
     @ManyToOne
     @JoinColumn(name = "owner_id", nullable = false)
     private User owner;
 
     private String displayName;
-    private UUID storageId;
+    private String storageId;
     private long fileSize;
 
     private String version;

--- a/src/main/java/in/lazygod/models/Folder.java
+++ b/src/main/java/in/lazygod/models/Folder.java
@@ -9,7 +9,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.UUID;
+
 
 @Entity
 @Data
@@ -18,9 +18,9 @@ import java.util.UUID;
 @Builder
 public class Folder {
     @Id
-    private UUID folderId;
+    private String folderId;
 
-    private UUID parentFolder;
+    private String parentFolder;
     private boolean isActive;
 
     private LocalDateTime createdOn;

--- a/src/main/java/in/lazygod/models/Storage.java
+++ b/src/main/java/in/lazygod/models/Storage.java
@@ -9,7 +9,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.UUID;
+
 
 @Entity
 @Data
@@ -18,7 +18,7 @@ import java.util.UUID;
 @Builder
 public class Storage {
     @Id
-    private UUID storageId;
+    private String storageId;
 
     private String storageName;
     private String basePath;

--- a/src/main/java/in/lazygod/models/User.java
+++ b/src/main/java/in/lazygod/models/User.java
@@ -8,7 +8,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.UUID;
+
 
 @Entity
 @Data
@@ -18,7 +18,7 @@ import java.util.UUID;
 @Table(name = "app_user")
 public class User {
     @Id
-    private UUID userId;
+    private String userId;
 
     @Column(unique = true, nullable = false)
     private String username;

--- a/src/main/java/in/lazygod/models/UserRights.java
+++ b/src/main/java/in/lazygod/models/UserRights.java
@@ -8,7 +8,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.UUID;
+
 
 @Entity
 @Data
@@ -17,11 +17,11 @@ import java.util.UUID;
 @Builder
 public class UserRights {
     @Id
-    private UUID urId;
+    private String urId;
 
-    private UUID userId;
-    private UUID fileId;
-    private UUID parentFolderId;
+    private String userId;
+    private String fileId;
+    private String parentFolderId;
 
     private String rightsType; // READ / WRITE / ADMIN
     private String resourceType; // FILE / FOLDER

--- a/src/main/java/in/lazygod/repositories/UserRepository.java
+++ b/src/main/java/in/lazygod/repositories/UserRepository.java
@@ -4,9 +4,8 @@ import in.lazygod.models.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
-import java.util.UUID;
 
-public interface UserRepository extends JpaRepository<User, UUID> {
+public interface UserRepository extends JpaRepository<User, String> {
 
     Optional<User> findByUsername(String username);
 }

--- a/src/main/java/in/lazygod/security/JwtUtil.java
+++ b/src/main/java/in/lazygod/security/JwtUtil.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component;
 
 import java.security.Key;
 import java.util.Date;
-import java.util.UUID;
 
 @Component
 public class JwtUtil {

--- a/src/main/java/in/lazygod/util/SnowflakeIdGenerator.java
+++ b/src/main/java/in/lazygod/util/SnowflakeIdGenerator.java
@@ -1,0 +1,58 @@
+package in.lazygod.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SnowflakeIdGenerator {
+    private final long nodeId;
+    private long sequence = 0L;
+    private long lastTimestamp = -1L;
+
+    private static final long NODE_ID_BITS = 10L;
+    private static final long MAX_NODE_ID = ~(-1L << NODE_ID_BITS);
+    private static final long SEQUENCE_BITS = 12L;
+
+    private static final long NODE_ID_SHIFT = SEQUENCE_BITS;
+    private static final long TIMESTAMP_LEFT_SHIFT = SEQUENCE_BITS + NODE_ID_BITS;
+    private static final long SEQUENCE_MASK = ~(-1L << SEQUENCE_BITS);
+    private static final long EPOCH = 1609459200000L; // 2021-01-01
+
+    public SnowflakeIdGenerator(@Value("${snowflake.node-id:1}") long nodeId) {
+        if (nodeId < 0 || nodeId > MAX_NODE_ID) {
+            throw new IllegalArgumentException("nodeId must be between 0 and " + MAX_NODE_ID);
+        }
+        this.nodeId = nodeId;
+    }
+
+    public synchronized String nextId() {
+        long currentTimestamp = timestamp();
+        if (currentTimestamp < lastTimestamp) {
+            throw new IllegalStateException("Clock moved backwards");
+        }
+        if (currentTimestamp == lastTimestamp) {
+            sequence = (sequence + 1) & SEQUENCE_MASK;
+            if (sequence == 0) {
+                currentTimestamp = waitNextMillis(currentTimestamp);
+            }
+        } else {
+            sequence = 0L;
+        }
+        lastTimestamp = currentTimestamp;
+        long id = ((currentTimestamp - EPOCH) << TIMESTAMP_LEFT_SHIFT)
+                | (nodeId << NODE_ID_SHIFT)
+                | sequence;
+        return Long.toUnsignedString(id);
+    }
+
+    private long waitNextMillis(long currentTimestamp) {
+        while (currentTimestamp == lastTimestamp) {
+            currentTimestamp = timestamp();
+        }
+        return currentTimestamp;
+    }
+
+    private long timestamp() {
+        return System.currentTimeMillis();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,3 +26,6 @@ logging:
 storage:
   local:
     base-path: files
+
+snowflake:
+  node-id: 1


### PR DESCRIPTION
## Summary
- convert entity IDs from `Long` to `String`
- expose snowflake node id via `application.yml`
- implement a `SnowflakeIdGenerator` bean using the node id property
- inject the generator into `AuthController`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688424a9d98083309432679ae851a702