### PR TITLE
Add skeleton APIs for storage and file operations

### DIFF
--- a/src/main/java/in/lazygod/controller/FileController.java
+++ b/src/main/java/in/lazygod/controller/FileController.java
@@ -1,26 +1,110 @@
 package in.lazygod.controller;
 
+import in.lazygod.models.File;
+import in.lazygod.models.UserRights;
+import in.lazygod.models.ActivityLog;
+import in.lazygod.repositories.FileRepository;
+import in.lazygod.repositories.UserRightsRepository;
+import in.lazygod.repositories.ActivityLogRepository;
+import in.lazygod.service.StorageService;
+import in.lazygod.util.SnowflakeIdGenerator;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/file")
 @SecurityRequirement(name = "bearer-key")
+@RequiredArgsConstructor
 public class FileController {
 
-    @GetMapping("/secure-data")
-    public ResponseEntity<String> securedEndpoint() {
-        return ResponseEntity.ok("Only with JWT!");
+    private final StorageService storageService;
+    private final FileRepository fileRepository;
+    private final UserRightsRepository rightsRepository;
+    private final ActivityLogRepository activityRepository;
+    private final SnowflakeIdGenerator idGenerator;
+
+    @PostMapping("/upload")
+    public ResponseEntity<File> upload(@RequestParam("file") MultipartFile file,
+                                       @RequestParam String userId,
+                                       @RequestParam String storageId) throws IOException {
+        String fileId = idGenerator.nextId();
+        String path = storageId + "/" + fileId;
+        storageService.upload(file, path);
+
+        File entity = File.builder()
+                .fileId(fileId)
+                .displayName(file.getOriginalFilename())
+                .storageId(storageId)
+                .fileSize(file.getSize())
+                .version("1")
+                .path(path)
+                .mimeType(file.getContentType())
+                .isActive(true)
+                .createdOn(LocalDateTime.now())
+                .updatedOn(LocalDateTime.now())
+                .build();
+        fileRepository.save(entity);
+
+        UserRights rights = UserRights.builder()
+                .urId(idGenerator.nextId())
+                .userId(userId)
+                .fileId(fileId)
+                .rightsType("ADMIN")
+                .resourceType("FILE")
+                .isFavourite(false)
+                .isActive(true)
+                .createdOn(LocalDateTime.now())
+                .updatedOn(LocalDateTime.now())
+                .build();
+        rightsRepository.save(rights);
+
+        activityRepository.save(ActivityLog.builder()
+                .activityId(idGenerator.nextId())
+                .userId(userId)
+                .action("UPLOAD_FILE")
+                .targetId(fileId)
+                .timestamp(LocalDateTime.now())
+                .build());
+
+        return ResponseEntity.ok(entity);
     }
 
+    @GetMapping("/{id}/download")
+    public ResponseEntity<Resource> download(@PathVariable("id") String fileId) throws IOException {
+        File file = fileRepository.findById(fileId).orElseThrow();
+        Resource resource = storageService.download(file.getPath());
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + file.getDisplayName())
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .body(resource);
+    }
 
-    @PreAuthorize("hasRole('ADMIN')")
-    @GetMapping("/admin/only")
-    public String adminOnly() {
-        return "You are an admin!";
+    @PostMapping("/{id}/favourite")
+    public ResponseEntity<Void> favourite(@PathVariable("id") String fileId,
+                                          @RequestParam String userId,
+                                          @RequestParam boolean fav) {
+        UserRights rights = rightsRepository.findByUserIdAndFileId(userId, fileId)
+                .orElseThrow();
+        rights.setFavourite(fav);
+        rights.setUpdatedOn(LocalDateTime.now());
+        rightsRepository.save(rights);
+
+        activityRepository.save(ActivityLog.builder()
+                .activityId(idGenerator.nextId())
+                .userId(userId)
+                .action(fav ? "FAV_FILE" : "UNFAV_FILE")
+                .targetId(fileId)
+                .timestamp(LocalDateTime.now())
+                .build());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/in/lazygod/controller/FolderController.java
+++ b/src/main/java/in/lazygod/controller/FolderController.java
@@ -1,0 +1,82 @@
+package in.lazygod.controller;
+
+import in.lazygod.models.ActivityLog;
+import in.lazygod.models.Folder;
+import in.lazygod.models.UserRights;
+import in.lazygod.repositories.ActivityLogRepository;
+import in.lazygod.repositories.FolderRepository;
+import in.lazygod.repositories.UserRightsRepository;
+import in.lazygod.util.SnowflakeIdGenerator;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequestMapping("/folder")
+@SecurityRequirement(name = "bearer-key")
+@RequiredArgsConstructor
+public class FolderController {
+
+    private final FolderRepository folderRepository;
+    private final UserRightsRepository rightsRepository;
+    private final ActivityLogRepository activityRepository;
+    private final SnowflakeIdGenerator idGenerator;
+
+    @PostMapping
+    public ResponseEntity<Folder> create(@RequestParam String userId,
+                                         @RequestParam(required = false) String parentId) {
+        Folder folder = Folder.builder()
+                .folderId(idGenerator.nextId())
+                .parentFolder(parentId)
+                .isActive(true)
+                .createdOn(LocalDateTime.now())
+                .updatedOn(LocalDateTime.now())
+                .build();
+        folderRepository.save(folder);
+
+        rightsRepository.save(UserRights.builder()
+                .urId(idGenerator.nextId())
+                .userId(userId)
+                .parentFolderId(folder.getFolderId())
+                .rightsType("ADMIN")
+                .resourceType("FOLDER")
+                .isFavourite(false)
+                .isActive(true)
+                .createdOn(LocalDateTime.now())
+                .updatedOn(LocalDateTime.now())
+                .build());
+
+        activityRepository.save(ActivityLog.builder()
+                .activityId(idGenerator.nextId())
+                .userId(userId)
+                .action("CREATE_FOLDER")
+                .targetId(folder.getFolderId())
+                .timestamp(LocalDateTime.now())
+                .build());
+
+        return ResponseEntity.ok(folder);
+    }
+
+    @PostMapping("/{id}/favourite")
+    public ResponseEntity<Void> favourite(@PathVariable("id") String folderId,
+                                          @RequestParam String userId,
+                                          @RequestParam boolean fav) {
+        UserRights rights = rightsRepository.findByUserIdAndParentFolderId(userId, folderId)
+                .orElseThrow();
+        rights.setFavourite(fav);
+        rights.setUpdatedOn(LocalDateTime.now());
+        rightsRepository.save(rights);
+
+        activityRepository.save(ActivityLog.builder()
+                .activityId(idGenerator.nextId())
+                .userId(userId)
+                .action(fav ? "FAV_FOLDER" : "UNFAV_FOLDER")
+                .targetId(folderId)
+                .timestamp(LocalDateTime.now())
+                .build());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/in/lazygod/controller/StorageController.java
+++ b/src/main/java/in/lazygod/controller/StorageController.java
@@ -1,0 +1,34 @@
+package in.lazygod.controller;
+
+import in.lazygod.models.Storage;
+import in.lazygod.repositories.StorageRepository;
+import in.lazygod.util.SnowflakeIdGenerator;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequestMapping("/storage")
+@SecurityRequirement(name = "bearer-key")
+@RequiredArgsConstructor
+public class StorageController {
+
+    private final StorageRepository storageRepository;
+    private final SnowflakeIdGenerator idGenerator;
+
+    @PostMapping
+    public ResponseEntity<Storage> createStorage(@RequestBody Storage storage) {
+        storage.setStorageId(idGenerator.nextId());
+        storage.setCreatedOn(LocalDateTime.now());
+        storage.setUpdatedOn(LocalDateTime.now());
+        storage.setActive(true);
+        Storage saved = storageRepository.save(storage);
+        return ResponseEntity.ok(saved);
+    }
+}

--- a/src/main/java/in/lazygod/models/ActivityLog.java
+++ b/src/main/java/in/lazygod/models/ActivityLog.java
@@ -1,0 +1,24 @@
+package in.lazygod.models;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ActivityLog {
+    @Id
+    private String activityId;
+    private String userId;
+    private String action;
+    private String targetId;
+    private LocalDateTime timestamp;
+}

--- a/src/main/java/in/lazygod/repositories/ActivityLogRepository.java
+++ b/src/main/java/in/lazygod/repositories/ActivityLogRepository.java
@@ -1,0 +1,7 @@
+package in.lazygod.repositories;
+
+import in.lazygod.models.ActivityLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ActivityLogRepository extends JpaRepository<ActivityLog, String> {
+}

--- a/src/main/java/in/lazygod/repositories/FileRepository.java
+++ b/src/main/java/in/lazygod/repositories/FileRepository.java
@@ -1,0 +1,7 @@
+package in.lazygod.repositories;
+
+import in.lazygod.models.File;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FileRepository extends JpaRepository<File, String> {
+}

--- a/src/main/java/in/lazygod/repositories/FolderRepository.java
+++ b/src/main/java/in/lazygod/repositories/FolderRepository.java
@@ -1,0 +1,7 @@
+package in.lazygod.repositories;
+
+import in.lazygod.models.Folder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FolderRepository extends JpaRepository<Folder, String> {
+}

--- a/src/main/java/in/lazygod/repositories/StorageRepository.java
+++ b/src/main/java/in/lazygod/repositories/StorageRepository.java
@@ -1,0 +1,7 @@
+package in.lazygod.repositories;
+
+import in.lazygod.models.Storage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StorageRepository extends JpaRepository<Storage, String> {
+}

--- a/src/main/java/in/lazygod/repositories/UserRightsRepository.java
+++ b/src/main/java/in/lazygod/repositories/UserRightsRepository.java
@@ -1,0 +1,9 @@
+package in.lazygod.repositories;
+
+import in.lazygod.models.UserRights;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRightsRepository extends JpaRepository<UserRights, String> {
+    java.util.Optional<UserRights> findByUserIdAndFileId(String userId, String fileId);
+    java.util.Optional<UserRights> findByUserIdAndParentFolderId(String userId, String parentFolderId);
+}

--- a/src/main/java/in/lazygod/service/impl/DummyStorageService.java
+++ b/src/main/java/in/lazygod/service/impl/DummyStorageService.java
@@ -1,0 +1,44 @@
+package in.lazygod.service.impl;
+
+import in.lazygod.service.StorageService;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory storage service used for development and testing.
+ */
+import org.springframework.context.annotation.Primary;
+
+@Service
+@Primary
+public class DummyStorageService implements StorageService {
+
+    private final Map<String, byte[]> store = new ConcurrentHashMap<>();
+
+    @Override
+    public void upload(MultipartFile file, String destinationPath) throws IOException {
+        store.put(destinationPath, file.getBytes());
+    }
+
+    @Override
+    public Resource download(String storagePath) throws IOException {
+        byte[] data = store.getOrDefault(storagePath, new byte[0]);
+        return new ByteArrayResource(data);
+    }
+
+    @Override
+    public void delete(String storagePath) throws IOException {
+        store.remove(storagePath);
+    }
+
+    @Override
+    public boolean exists(String storagePath) throws IOException {
+        return store.containsKey(storagePath);
+    }
+}


### PR DESCRIPTION
## Summary
- implement a simple in-memory `DummyStorageService`
- add repositories for files, folders, storages, rights, and activity logs
- create `StorageController`, `FileController`, and `FolderController` with minimal endpoints
- support marking files and folders as favourite
- track operations in new `ActivityLog` entity

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68850dafed448330a82a16fcaeaf778b