### PR TITLE
Improve storage APIs to use current user

### DIFF
--- a/src/main/java/in/lazygod/controller/StorageController.java
+++ b/src/main/java/in/lazygod/controller/StorageController.java
@@ -1,7 +1,6 @@
 package in.lazygod.controller;
 
 import in.lazygod.models.Storage;
-import in.lazygod.models.User;
 import in.lazygod.service.StorageManagementService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
@@ -25,16 +24,14 @@ public class StorageController {
 
     @PostMapping
     public ResponseEntity<Storage> createStorage(@RequestBody Storage storage) {
-        // Owner is currently fetched via the provided owner_id field
-        User owner = storage.getOwner();
-        Storage saved = storageManagementService.createStorage(storage, owner);
+        Storage saved = storageManagementService.createStorage(storage);
         log.info("Created storage {}", saved.getStorageId());
         return ResponseEntity.ok(saved);
     }
 
     @GetMapping
-    public ResponseEntity<java.util.List<Storage>> listStorages(@RequestBody User user) {
-        var list = storageManagementService.listStorages(user);
+    public ResponseEntity<java.util.List<Storage>> listStorages() {
+        var list = storageManagementService.listStorages();
         return ResponseEntity.ok(list);
     }
 }

--- a/src/main/java/in/lazygod/service/StorageManagementService.java
+++ b/src/main/java/in/lazygod/service/StorageManagementService.java
@@ -10,7 +10,7 @@ import java.util.List;
  */
 public interface StorageManagementService {
 
-    Storage createStorage(Storage storage, User owner);
+    Storage createStorage(Storage storage);
 
-    List<Storage> listStorages(User owner);
+    List<Storage> listStorages();
 }

--- a/src/main/java/in/lazygod/service/StorageManagementServiceImpl.java
+++ b/src/main/java/in/lazygod/service/StorageManagementServiceImpl.java
@@ -3,6 +3,7 @@ package in.lazygod.service;
 import in.lazygod.models.Storage;
 import in.lazygod.models.User;
 import in.lazygod.repositories.StorageRepository;
+import in.lazygod.security.SecurityContextHolderUtil;
 import in.lazygod.util.SnowflakeIdGenerator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,7 +24,8 @@ public class StorageManagementServiceImpl implements StorageManagementService {
     private final SnowflakeIdGenerator idGenerator;
 
     @Override
-    public Storage createStorage(Storage storage, User owner) {
+    public Storage createStorage(Storage storage) {
+        User owner = SecurityContextHolderUtil.getCurrentUser();
         log.info("Creating storage {} for user {}", storage.getStorageName(), owner.getUserId());
         storage.setStorageId(idGenerator.nextId());
         storage.setOwner(owner);
@@ -34,7 +36,8 @@ public class StorageManagementServiceImpl implements StorageManagementService {
     }
 
     @Override
-    public List<Storage> listStorages(User owner) {
+    public List<Storage> listStorages() {
+        User owner = SecurityContextHolderUtil.getCurrentUser();
         log.debug("Listing storages for user {}", owner.getUserId());
         return storageRepository.findByOwner(owner);
     }


### PR DESCRIPTION
## Summary
- simplify storage API to fetch owner from `SecurityContextHolderUtil`
- list storages and create storage for the authenticated user only

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68863e7b6b3c8330821a27ad312ab1fe