### PR TITLE
Add cache for StorageFactory

### DIFF
--- a/src/main/java/in/lazygod/stoageUtils/StorageFactory.java
+++ b/src/main/java/in/lazygod/stoageUtils/StorageFactory.java
@@ -2,20 +2,66 @@ package in.lazygod.stoageUtils;
 
 import in.lazygod.models.Storage;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Factory responsible for providing {@link StorageImpl} instances.
+ * <p>
+ * Creating a new {@link StorageImpl} can be expensive depending on the
+ * underlying implementation (e.g. establishing S3 clients). To avoid
+ * repeatedly creating the same instance, we cache implementations for a
+ * short time. Each cache entry is identified by the {@link Storage#getStorageId()}
+ * of the configuration used to create it.
+ */
 public class StorageFactory {
 
-    public static StorageImpl getStorageImpl(Storage config){
+    /** Entries stay in the cache for this duration. */
+    private static final Duration CACHE_TTL = Duration.ofMinutes(10);
 
-        switch (config.getStorageType()){
-            case LOCAL -> {
-                return new LocalStorage(config.getBasePath());
-            }
-            case S3 -> {
-                return new S3Storage();
-            }
-            default -> {
-                return new DummyStorage();
-            }
+    /**
+     * Wrapper for a cached instance with its creation timestamp.
+     */
+    private static class CachedEntry {
+        private final StorageImpl impl;
+        private final Instant created;
+
+        CachedEntry(StorageImpl impl) {
+            this.impl = impl;
+            this.created = Instant.now();
         }
+
+        boolean expired() {
+            return Instant.now().isAfter(created.plus(CACHE_TTL));
+        }
+    }
+
+    /** Cache keyed by storageId. */
+    private static final Map<String, CachedEntry> CACHE = new ConcurrentHashMap<>();
+
+    /**
+     * Obtain a {@link StorageImpl} for the given storage configuration.
+     *
+     * @param config storage configuration
+     * @return a cached or newly created implementation
+     */
+    public static StorageImpl getStorageImpl(Storage config){
+        String key = config.getStorageId();
+        CachedEntry cached = CACHE.get(key);
+        if (cached != null && !cached.expired()) {
+            return cached.impl;
+        }
+
+        StorageImpl impl;
+        switch (config.getStorageType()){
+            case LOCAL -> impl = new LocalStorage(config.getBasePath());
+            case S3 -> impl = new S3Storage();
+            default -> impl = new DummyStorage();
+        }
+
+        CACHE.put(key, new CachedEntry(impl));
+        return impl;
     }
 }


### PR DESCRIPTION
## Summary
- implement a simple time-based cache in `StorageFactory`
- cache entries expire after 10 minutes to prevent repeated instantiation

## Testing
- `mvn -q -DskipTests=false test` *(fails: could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688641ce74d48330b3769974ba22570e