### PR TITLE
Add basic websocket handlers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,12 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
+        <!-- WebSocket support -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-websocket</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>

--- a/src/main/java/in/lazygod/websocket/FeatureHandler.java
+++ b/src/main/java/in/lazygod/websocket/FeatureHandler.java
@@ -1,0 +1,40 @@
+package in.lazygod.websocket;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * Returns the list of supported websocket features.
+ */
+@Component
+@RequiredArgsConstructor
+public class FeatureHandler implements WsMessageHandler {
+
+    private final HandlerRegistry registry;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @PostConstruct
+    public void init() {
+        registry.register(this);
+    }
+
+    @Override
+    public String type() {
+        return "features";
+    }
+
+    @Override
+    public void handle(WebSocketSession session, JsonNode payload) throws IOException {
+        Set<String> types = registry.getHandlers().keySet();
+        String response = mapper.writeValueAsString(types);
+        session.sendMessage(new TextMessage("{\"type\":\"features\",\"payload\":" + response + "}"));
+    }
+}

--- a/src/main/java/in/lazygod/websocket/HandlerRegistry.java
+++ b/src/main/java/in/lazygod/websocket/HandlerRegistry.java
@@ -1,0 +1,32 @@
+package in.lazygod.websocket;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Registry maintaining mapping between message types and their handlers.
+ */
+@Component
+public class HandlerRegistry {
+
+    private final Map<String, WsMessageHandler> handlers = new ConcurrentHashMap<>();
+
+    /**
+     * Register a handler for a specific type.
+     *
+     * @param handler handler instance
+     */
+    public void register(WsMessageHandler handler) {
+        handlers.put(handler.type(), handler);
+    }
+
+    public WsMessageHandler get(String type) {
+        return handlers.get(type);
+    }
+
+    public Map<String, WsMessageHandler> getHandlers() {
+        return handlers;
+    }
+}

--- a/src/main/java/in/lazygod/websocket/MainWebSocketHandler.java
+++ b/src/main/java/in/lazygod/websocket/MainWebSocketHandler.java
@@ -1,0 +1,37 @@
+package in.lazygod.websocket;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MainWebSocketHandler extends TextWebSocketHandler {
+
+    private final HandlerRegistry registry;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+        JsonNode node = mapper.readTree(message.getPayload());
+        String type = node.has("type") ? node.get("type").asText() : null;
+        JsonNode payload = node.get("payload");
+
+        if (type == null) {
+            log.warn("Missing message type: {}", message.getPayload());
+            return;
+        }
+        WsMessageHandler handler = registry.get(type);
+        if (handler == null) {
+            log.warn("No handler registered for type {}", type);
+            return;
+        }
+        handler.handle(session, payload);
+    }
+}

--- a/src/main/java/in/lazygod/websocket/PingPongHandler.java
+++ b/src/main/java/in/lazygod/websocket/PingPongHandler.java
@@ -1,0 +1,38 @@
+package in.lazygod.websocket;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+
+/**
+ * Simple ping/pong handler.
+ */
+
+@Component
+public class PingPongHandler implements WsMessageHandler {
+
+    private final HandlerRegistry registry;
+
+    public PingPongHandler(HandlerRegistry registry) {
+        this.registry = registry;
+    }
+
+    @PostConstruct
+    public void init() {
+        registry.register(this);
+    }
+
+    @Override
+    public String type() {
+        return "ping";
+    }
+
+    @Override
+    public void handle(WebSocketSession session, JsonNode payload) throws IOException {
+        session.sendMessage(new TextMessage("{\"type\":\"pong\"}"));
+    }
+}

--- a/src/main/java/in/lazygod/websocket/WebSocketConfig.java
+++ b/src/main/java/in/lazygod/websocket/WebSocketConfig.java
@@ -1,0 +1,23 @@
+package in.lazygod.websocket;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketConfigurer {
+
+    private final MainWebSocketHandler mainHandler;
+    private final PingPongHandler pingPongHandler;
+    private final FeatureHandler featureHandler;
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry handlerRegistry) {
+        handlerRegistry.addHandler(mainHandler, "/ws")
+                .setAllowedOriginPatterns("*");
+    }
+}

--- a/src/main/java/in/lazygod/websocket/WsMessageHandler.java
+++ b/src/main/java/in/lazygod/websocket/WsMessageHandler.java
@@ -1,0 +1,22 @@
+package in.lazygod.websocket;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+
+/**
+ * Contract for handling websocket messages for a specific type.
+ */
+public interface WsMessageHandler {
+
+    /**
+     * Unique message type this handler supports.
+     */
+    String type();
+
+    /**
+     * Handle an incoming message payload.
+     */
+    void handle(WebSocketSession session, JsonNode payload) throws IOException;
+}


### PR DESCRIPTION
## Summary
- add spring-boot-starter-websocket dependency
- implement a simple websocket framework with registry
- include ping/pong and feature handlers

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6886538051188330ba70069930b80ada