### PR TITLE
Implement custom exceptions and i18n

### DIFF
--- a/src/main/java/in/lazygod/config/MessageConfig.java
+++ b/src/main/java/in/lazygod/config/MessageConfig.java
@@ -1,0 +1,29 @@
+package in.lazygod.config;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
+
+import java.util.Locale;
+
+@Configuration
+public class MessageConfig {
+
+    @Bean
+    public MessageSource messageSource() {
+        ReloadableResourceBundleMessageSource source = new ReloadableResourceBundleMessageSource();
+        source.setBasename("classpath:messages");
+        source.setDefaultEncoding("UTF-8");
+        return source;
+    }
+
+    @Bean
+    public LocaleResolver localeResolver() {
+        AcceptHeaderLocaleResolver resolver = new AcceptHeaderLocaleResolver();
+        resolver.setDefaultLocale(Locale.ENGLISH);
+        return resolver;
+    }
+}

--- a/src/main/java/in/lazygod/controller/AuthController.java
+++ b/src/main/java/in/lazygod/controller/AuthController.java
@@ -44,7 +44,8 @@ public class AuthController {
         if (!jwtUtil.validateToken(request.refreshToken)) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
-        User user = userRepository.findByUsername(username).orElseThrow(()->new RuntimeException("User not found"));
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new in.lazygod.exception.NotFoundException("user.not.found"));
         return ResponseEntity.ok(authService.generateTokens(user));
     }
 

--- a/src/main/java/in/lazygod/dto/ErrorResponse.java
+++ b/src/main/java/in/lazygod/dto/ErrorResponse.java
@@ -1,0 +1,3 @@
+package in.lazygod.dto;
+
+public record ErrorResponse(int status, String message) {}

--- a/src/main/java/in/lazygod/exception/ApiException.java
+++ b/src/main/java/in/lazygod/exception/ApiException.java
@@ -1,0 +1,22 @@
+package in.lazygod.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ApiException extends RuntimeException {
+    private final String messageKey;
+    private final HttpStatus status;
+
+    public ApiException(String messageKey, HttpStatus status) {
+        super(messageKey);
+        this.messageKey = messageKey;
+        this.status = status;
+    }
+
+    public String getMessageKey() {
+        return messageKey;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/in/lazygod/exception/BadRequestException.java
+++ b/src/main/java/in/lazygod/exception/BadRequestException.java
@@ -1,0 +1,9 @@
+package in.lazygod.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class BadRequestException extends ApiException {
+    public BadRequestException(String messageKey) {
+        super(messageKey, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/in/lazygod/exception/ForbiddenException.java
+++ b/src/main/java/in/lazygod/exception/ForbiddenException.java
@@ -1,0 +1,9 @@
+package in.lazygod.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ForbiddenException extends ApiException {
+    public ForbiddenException(String messageKey) {
+        super(messageKey, HttpStatus.FORBIDDEN);
+    }
+}

--- a/src/main/java/in/lazygod/exception/NotFoundException.java
+++ b/src/main/java/in/lazygod/exception/NotFoundException.java
@@ -1,0 +1,9 @@
+package in.lazygod.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundException extends ApiException {
+    public NotFoundException(String messageKey) {
+        super(messageKey, HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/in/lazygod/handler/GlobalExceptionHandler.java
+++ b/src/main/java/in/lazygod/handler/GlobalExceptionHandler.java
@@ -1,5 +1,9 @@
 package in.lazygod.handler;
 
+import in.lazygod.dto.ErrorResponse;
+import in.lazygod.exception.ApiException;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -7,8 +11,16 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<String> handleRuntime(RuntimeException e) {
-        return ResponseEntity.badRequest().body("Error: " + e.getMessage());
+    private final MessageSource messageSource;
+
+    public GlobalExceptionHandler(MessageSource messageSource) {
+        this.messageSource = messageSource;
+    }
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ErrorResponse> handleApi(ApiException e) {
+        String msg = messageSource.getMessage(e.getMessageKey(), null, LocaleContextHolder.getLocale());
+        return ResponseEntity.status(e.getStatus())
+                .body(new ErrorResponse(e.getStatus().value(), msg));
     }
 }

--- a/src/main/java/in/lazygod/service/AuthService.java
+++ b/src/main/java/in/lazygod/service/AuthService.java
@@ -35,7 +35,7 @@ public class AuthService {
     public User register(@RequestBody RegisterRequest request) {
         Optional<User> existing = userRepository.findByUsername(request.getUsername());
         if (existing.isPresent()) {
-            throw new RuntimeException("User already exists");
+            throw new in.lazygod.exception.BadRequestException("user.exists");
         }
 
         User user = User.builder()
@@ -66,7 +66,8 @@ public class AuthService {
     @Transactional
     public AuthResponse verifyUser(String userId, VerificationRequest request) {
 
-        User user = userRepository.findById(userId).orElseThrow(()->new RuntimeException("User not found"));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new in.lazygod.exception.NotFoundException("user.not.found"));
 
         if(passwordEncoder.matches(request.getVerificationCode(), user.getVerificationCode())){
             user.setVerification(Verification.VERIFIED);
@@ -84,6 +85,6 @@ public class AuthService {
             return generateTokens(user);
         }
 
-        throw new RuntimeException("Verification failed ! incorrect verification code");
+        throw new in.lazygod.exception.BadRequestException("verification.failed");
     }
 }

--- a/src/main/java/in/lazygod/service/FileService.java
+++ b/src/main/java/in/lazygod/service/FileService.java
@@ -40,15 +40,15 @@ public class FileService {
         User user = SecurityContextHolderUtil.getCurrentUser();
 
         Folder folder = folderId==null || folderId.isBlank() ?
-                folderRepository.findById(user.getUsername()).orElseThrow(()-> new RuntimeException("Folder not found") )
-                :folderRepository.findById(folderId).orElseThrow(()-> new RuntimeException("Folder not found") );
+                folderRepository.findById(user.getUsername()).orElseThrow(() -> new in.lazygod.exception.NotFoundException("folder.not.found") )
+                :folderRepository.findById(folderId).orElseThrow(() -> new in.lazygod.exception.NotFoundException("folder.not.found") );
 
         UserRights folderRight = rightsRepository.findByUserIdAndFileIdAndResourceType(user.getUserId(), folder.getFolderId(), ResourceType.FOLDER)
-                .orElseThrow(() -> new RuntimeException("Resource not authorized"));
+                .orElseThrow(() -> new in.lazygod.exception.ForbiddenException("resource.not.authorized"));
 
         if (!folderRight.getRightsType().equals(FileRights.ADMIN)
                 && !folderRight.getRightsType().equals(FileRights.WRITE)) {
-            throw new RuntimeException("Action not authorized");
+            throw new in.lazygod.exception.ForbiddenException("action.not.authorized");
         }
 
         String fileId = idGenerator.nextId();
@@ -115,10 +115,11 @@ public class FileService {
     public FileResponse download(String fileId) throws IOException {
         User user = SecurityContextHolderUtil.getCurrentUser();
 
-        File file = fileRepository.findById(fileId).orElseThrow(()-> new RuntimeException("Resource not found"));
+        File file = fileRepository.findById(fileId)
+                .orElseThrow(() -> new in.lazygod.exception.NotFoundException("resource.not.found"));
 
         UserRights rights = rightsRepository.findByUserIdAndFileIdAndResourceType(user.getUserId(), file.getFileId(), ResourceType.FILE)
-                .orElseThrow(()->new RuntimeException("Resource not authorized"));
+                .orElseThrow(() -> new in.lazygod.exception.ForbiddenException("resource.not.authorized"));
 
         activityRepository.save(ActivityLog.builder()
                 .activityId(idGenerator.nextId())

--- a/src/main/java/in/lazygod/service/FolderService.java
+++ b/src/main/java/in/lazygod/service/FolderService.java
@@ -42,15 +42,15 @@ public class FolderService {
         User user = SecurityContextHolderUtil.getCurrentUser();
 
         Folder parentFolder = parentId==null || parentId.isBlank() ?
-                folderRepository.findById(user.getUsername()).orElseThrow(()-> new RuntimeException("Folder not found") )
-                :folderRepository.findById(parentId).orElseThrow(()-> new RuntimeException("Folder not found") );
+                folderRepository.findById(user.getUsername()).orElseThrow(() -> new in.lazygod.exception.NotFoundException("folder.not.found") )
+                :folderRepository.findById(parentId).orElseThrow(() -> new in.lazygod.exception.NotFoundException("folder.not.found") );
 
         UserRights folderRight = rightsRepository.findByUserIdAndFileIdAndResourceType(user.getUserId(), parentFolder.getFolderId(), ResourceType.FOLDER)
-                .orElseThrow(() -> new RuntimeException("Resource not authorized"));
+                .orElseThrow(() -> new in.lazygod.exception.ForbiddenException("resource.not.authorized"));
 
         if (!folderRight.getRightsType().equals(FileRights.ADMIN)
                 && !folderRight.getRightsType().equals(FileRights.WRITE)) {
-            throw new RuntimeException("Action not authorized");
+            throw new in.lazygod.exception.ForbiddenException("action.not.authorized");
         }
         Folder folder = Folder.builder()
                 .folderId(idGenerator.nextId())
@@ -115,7 +115,7 @@ public class FolderService {
     public void markFavourite(String folderId, boolean fav) {
         User user = SecurityContextHolderUtil.getCurrentUser();
         UserRights rights = rightsRepository.findByUserIdAndParentFolderId(user.getUserId(), folderId)
-                .orElseThrow(() -> new RuntimeException("Not authorized"));
+                .orElseThrow(() -> new in.lazygod.exception.ForbiddenException("not.authorized"));
 
         rights.setFavourite(fav);
         rights.setUpdatedOn(LocalDateTime.now());
@@ -138,10 +138,10 @@ public class FolderService {
         String targetId = (folderId == null || folderId.isBlank()) ? user.getUsername() : folderId;
 
         Folder folder = folderRepository.findById(targetId)
-                .orElseThrow(() -> new RuntimeException("Folder not found"));
+                .orElseThrow(() -> new in.lazygod.exception.NotFoundException("folder.not.found"));
 
         rightsRepository.findByUserIdAndParentFolderId(user.getUserId(), folder.getFolderId())
-                .orElseThrow(() -> new RuntimeException("Resource not authorized"));
+                .orElseThrow(() -> new in.lazygod.exception.ForbiddenException("resource.not.authorized"));
 
         Pageable pageable = PageRequest.of(page, size);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,8 @@ server:
       enabled: true
 
 spring:
+  messages:
+    basename: messages
   datasource:
     url: jdbc:h2:mem:filedb;DB_CLOSE_DELAY=-1
     driver-class-name: org.h2.Driver

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,0 +1,8 @@
+folder.not.found=Folder not found
+resource.not.authorized=Resource not authorized
+action.not.authorized=Action not authorized
+resource.not.found=Resource not found
+user.exists=User already exists
+user.not.found=User not found
+verification.failed=Verification failed! incorrect verification code
+not.authorized=Not authorized

--- a/src/main/resources/messages_fr.properties
+++ b/src/main/resources/messages_fr.properties
@@ -1,0 +1,8 @@
+folder.not.found=Dossier introuvable
+resource.not.authorized=Ressource non autorisée
+action.not.authorized=Action non autorisée
+resource.not.found=Ressource introuvable
+user.exists=Utilisateur existant
+user.not.found=Utilisateur introuvable
+verification.failed=Échec de la vérification! code incorrect
+not.authorized=Non autorisé


### PR DESCRIPTION
## Summary
- introduce ApiException hierarchy and ErrorResponse dto
- handle ApiException in GlobalExceptionHandler with MessageSource
- add MessageConfig to setup i18n support
- add English and French message bundles
- replace RuntimeExceptions with custom exceptions
- wire up message base in `application.yml`

## Testing
- `mvn -q -DskipTests=true package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6886541610748330bce66ae089276402