### PR TITLE
Dockerize project and switch to MySQL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM maven:3.9.6-eclipse-temurin-17 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn -B package -DskipTests
+
+# Run stage
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.8'
+services:
+  db:
+    image: mysql:8
+    restart: always
+    environment:
+      MYSQL_DATABASE: filedb
+      MYSQL_ROOT_PASSWORD: password
+    ports:
+      - "3306:3306"
+    volumes:
+      - db_data:/var/lib/mysql
+
+  app:
+    build: .
+    depends_on:
+      - db
+    ports:
+      - "8080:8080"
+    environment:
+      DB_HOST: db
+      DB_PORT: 3306
+      DB_NAME: filedb
+      DB_USER: root
+      DB_PASSWORD: password
+volumes:
+  db_data:

--- a/pom.xml
+++ b/pom.xml
@@ -41,14 +41,15 @@
             <version>2.3.0</version>
         </dependency>
 
-        <!-- JPA and H2/Postgres/MySQL -->
+        <!-- JPA and Database Driver -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
-        <dependency> <!-- Use only one: H2 (dev) or Postgres/MySQL -->
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
+        <!-- MySQL Driver -->
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
             <scope>runtime</scope>
         </dependency>
 

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,17 @@ mvn clean install
 ./mvnw spring-boot:run
 ```
 
+### 🐳 Running with Docker Compose
+
+To start the application together with a MySQL database run:
+
+```bash
+docker-compose up --build
+```
+
+The database credentials can be tweaked via the `DB_*` environment variables in
+`docker-compose.yml`.
+
 ## 🎯 Project Goals
 
 - **Application Storage**: users can store files in the application's default storage

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,15 +10,15 @@ spring:
   messages:
     basename: messages
   datasource:
-    url: jdbc:h2:mem:filedb;DB_CLOSE_DELAY=-1
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
+    url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:filedb}?createDatabaseIfNotExist=true&useSSL=false&allowPublicKeyRetrieval=true
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${DB_USER:root}
+    password: ${DB_PASSWORD:password}
   jpa:
     hibernate:
       ddl-auto: update
     show-sql: true
-    database-platform: org.hibernate.dialect.H2Dialect
+    database-platform: org.hibernate.dialect.MySQLDialect
 
 logging:
   level:


### PR DESCRIPTION
## Summary
- add a Dockerfile for container builds
- provide docker-compose with a MySQL service
- replace H2 with MySQL configuration
- expose DB settings through environment variables
- update README with compose instructions

## Testing
- `mvn -q test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6886743ff6f4833087a6fcb0421da5d6