### PR TITLE
Implement user connections and notifications

### DIFF
--- a/src/main/java/in/lazygod/controller/ConnectionController.java
+++ b/src/main/java/in/lazygod/controller/ConnectionController.java
@@ -1,0 +1,34 @@
+package in.lazygod.controller;
+
+import in.lazygod.models.Connection;
+import in.lazygod.service.ConnectionService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/connections")
+@SecurityRequirement(name = "bearer-key")
+@RequiredArgsConstructor
+public class ConnectionController {
+
+    private final ConnectionService connectionService;
+
+    @PostMapping("/request/{username}")
+    public ResponseEntity<Connection> request(@PathVariable String username) {
+        return ResponseEntity.ok(connectionService.sendRequest(username));
+    }
+
+    @PostMapping("/{id}/accept")
+    public ResponseEntity<Connection> accept(@PathVariable("id") String id) {
+        return ResponseEntity.ok(connectionService.acceptRequest(id));
+    }
+
+    @GetMapping("/pending")
+    public ResponseEntity<List<Connection>> pending() {
+        return ResponseEntity.ok(connectionService.pendingRequests());
+    }
+}

--- a/src/main/java/in/lazygod/controller/UserController.java
+++ b/src/main/java/in/lazygod/controller/UserController.java
@@ -1,0 +1,25 @@
+package in.lazygod.controller;
+
+import in.lazygod.models.User;
+import in.lazygod.repositories.UserRepository;
+import in.lazygod.security.SecurityContextHolderUtil;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users")
+@SecurityRequirement(name = "bearer-key")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserRepository userRepository;
+
+    @GetMapping("/me")
+    public ResponseEntity<User> me() {
+        return ResponseEntity.ok(SecurityContextHolderUtil.getCurrentUser());
+    }
+}

--- a/src/main/java/in/lazygod/enums/ConnectionStatus.java
+++ b/src/main/java/in/lazygod/enums/ConnectionStatus.java
@@ -1,0 +1,7 @@
+package in.lazygod.enums;
+
+public enum ConnectionStatus {
+    PENDING,
+    ACCEPTED,
+    REJECTED
+}

--- a/src/main/java/in/lazygod/models/Connection.java
+++ b/src/main/java/in/lazygod/models/Connection.java
@@ -1,0 +1,29 @@
+package in.lazygod.models;
+
+import in.lazygod.enums.ConnectionStatus;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Connection {
+    @Id
+    private String connectionId;
+
+    private String fromUserId;
+    private String toUserId;
+
+    @Enumerated(EnumType.STRING)
+    private ConnectionStatus status;
+
+    private LocalDateTime createdOn;
+    private LocalDateTime updatedOn;
+}

--- a/src/main/java/in/lazygod/repositories/ConnectionRepository.java
+++ b/src/main/java/in/lazygod/repositories/ConnectionRepository.java
@@ -1,0 +1,14 @@
+package in.lazygod.repositories;
+
+import in.lazygod.enums.ConnectionStatus;
+import in.lazygod.models.Connection;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ConnectionRepository extends JpaRepository<Connection, String> {
+    Optional<Connection> findByFromUserIdAndToUserId(String fromUserId, String toUserId);
+    List<Connection> findByToUserIdAndStatus(String toUserId, ConnectionStatus status);
+    List<Connection> findByFromUserIdAndStatus(String fromUserId, ConnectionStatus status);
+}

--- a/src/main/java/in/lazygod/service/ConnectionService.java
+++ b/src/main/java/in/lazygod/service/ConnectionService.java
@@ -1,0 +1,78 @@
+package in.lazygod.service;
+
+import in.lazygod.enums.ConnectionStatus;
+import in.lazygod.models.Connection;
+import in.lazygod.models.User;
+import in.lazygod.repositories.ConnectionRepository;
+import in.lazygod.repositories.UserRepository;
+import in.lazygod.security.SecurityContextHolderUtil;
+import in.lazygod.util.SnowflakeIdGenerator;
+import in.lazygod.websocket.handlers.NotificationHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ConnectionService {
+
+    private final ConnectionRepository connectionRepository;
+    private final UserRepository userRepository;
+    private final SnowflakeIdGenerator idGenerator;
+
+    @Transactional
+    public Connection sendRequest(String username) {
+        User from = SecurityContextHolderUtil.getCurrentUser();
+        User to = userRepository.findByUsername(username)
+                .orElseThrow(() -> new in.lazygod.exception.NotFoundException("user.not.found"));
+
+        connectionRepository.findByFromUserIdAndToUserId(from.getUserId(), to.getUserId())
+                .ifPresent(c -> { throw new in.lazygod.exception.BadRequestException("connection.exists"); });
+
+        Connection connection = Connection.builder()
+                .connectionId(idGenerator.nextId())
+                .fromUserId(from.getUserId())
+                .toUserId(to.getUserId())
+                .status(ConnectionStatus.PENDING)
+                .createdOn(LocalDateTime.now())
+                .updatedOn(LocalDateTime.now())
+                .build();
+
+        connectionRepository.save(connection);
+
+        // notify recipient if online
+        NotificationHandler.send(to.getUsername(), from.getUsername(), "connection-request", null);
+
+        return connection;
+    }
+
+    @Transactional
+    public Connection acceptRequest(String connectionId) {
+        User current = SecurityContextHolderUtil.getCurrentUser();
+        Connection connection = connectionRepository.findById(connectionId)
+                .orElseThrow(() -> new in.lazygod.exception.NotFoundException("connection.not.found"));
+
+        if (!connection.getToUserId().equals(current.getUserId())) {
+            throw new in.lazygod.exception.ForbiddenException("not.authorized");
+        }
+
+        connection.setStatus(ConnectionStatus.ACCEPTED);
+        connection.setUpdatedOn(LocalDateTime.now());
+        connectionRepository.save(connection);
+
+        // notify requester if online
+        userRepository.findById(connection.getFromUserId()).ifPresent(fromUser ->
+                NotificationHandler.send(fromUser.getUsername(), current.getUsername(), "connection-accepted", null)
+        );
+
+        return connection;
+    }
+
+    public List<Connection> pendingRequests() {
+        User current = SecurityContextHolderUtil.getCurrentUser();
+        return connectionRepository.findByToUserIdAndStatus(current.getUserId(), ConnectionStatus.PENDING);
+    }
+}

--- a/src/main/java/in/lazygod/websocket/handlers/HandlerInitializer.java
+++ b/src/main/java/in/lazygod/websocket/handlers/HandlerInitializer.java
@@ -5,6 +5,7 @@ public class HandlerInitializer {
     public static void registerAll() {
         FeatureHandler.register();
         PingPongHandler.register();
+        NotificationHandler.register();
         // add more as you create them
     }
 }

--- a/src/main/java/in/lazygod/websocket/handlers/NotificationHandler.java
+++ b/src/main/java/in/lazygod/websocket/handlers/NotificationHandler.java
@@ -1,0 +1,36 @@
+package in.lazygod.websocket.handlers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import in.lazygod.websocket.manager.UserSessionManager;
+import in.lazygod.websocket.model.Packet;
+import in.lazygod.websocket.model.SessionWrapper;
+
+public class NotificationHandler implements WsMessageHandler {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public String type() {
+        return "notification";
+    }
+
+    @Override
+    public void handle(SessionWrapper wrapper, JsonNode payload) {
+        // No-op. Notifications are pushed from server side.
+    }
+
+    public static void send(String username, String from, String type, JsonNode payload) {
+        Packet packet = Packet.builder()
+                .from(from)
+                .to(username)
+                .type(type)
+                .payload(payload)
+                .build();
+        UserSessionManager.getInstance().sendToUser(username, packet);
+    }
+
+    public static void register() {
+        HandlerRegistry.getInstance().register(new NotificationHandler());
+    }
+}


### PR DESCRIPTION
## Summary
- add new REST endpoint to get current user info
- allow sending and accepting connection requests
- store connection state in new entity
- push websocket notifications for connection events

## Testing
- `mvn -q -DskipTests install` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68868faee1c08330975b97c08e606d0d