### PR TITLE
Add H2 dev profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,12 @@
             <scope>runtime</scope>
             <version>8.0.33</version>
         </dependency>
+        <!-- H2 Driver for dev profile -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 
         <!-- Security -->
         <dependency>

--- a/readme.md
+++ b/readme.md
@@ -41,8 +41,8 @@ A Spring Boot-based file management server with full S3 capabilities, JWT authen
 # Build project
 mvn clean install
 
-# Run app
-./mvnw spring-boot:run
+# Run app with the in-memory H2 database
+./mvnw spring-boot:run -Dspring-boot.run.profiles=dev
 ```
 
 ### 🐳 Running with Docker Compose
@@ -53,7 +53,8 @@ To start the application together with a MySQL database run:
 docker-compose up --build
 ```
 
-The database credentials can be tweaked via the `DB_*` environment variables in
+The application will use the default MySQL configuration from `application.yml`.
+Database credentials can be tweaked via the `DB_*` environment variables in
 `docker-compose.yml`.
 
 ## 🎯 Project Goals

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,11 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:filedb;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    database-platform: org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
## Summary
- add H2 dev datasource configuration
- include H2 driver dependency
- document how to run the dev profile

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6887d7d1070083308cb9c8ad575d81a3