### PR TITLE
Add API logging and user rights endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,12 @@
             <artifactId>spring-boot-starter-logging</artifactId>
         </dependency>
 
+        <!-- Spring AOP for logging aspect -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+
         <!-- Lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/src/main/java/in/lazygod/config/LoggingAspect.java
+++ b/src/main/java/in/lazygod/config/LoggingAspect.java
@@ -1,0 +1,25 @@
+package in.lazygod.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class LoggingAspect {
+
+    @Around("within(@org.springframework.web.bind.annotation.RestController *)")
+    public Object logAround(ProceedingJoinPoint joinPoint) throws Throwable {
+        long start = System.currentTimeMillis();
+        log.info("API START {}.{}", joinPoint.getSignature().getDeclaringTypeName(), joinPoint.getSignature().getName());
+        try {
+            return joinPoint.proceed();
+        } finally {
+            long time = System.currentTimeMillis() - start;
+            log.info("API END {}.{} took {} ms", joinPoint.getSignature().getDeclaringTypeName(), joinPoint.getSignature().getName(), time);
+        }
+    }
+}

--- a/src/main/java/in/lazygod/controller/RightsController.java
+++ b/src/main/java/in/lazygod/controller/RightsController.java
@@ -1,0 +1,38 @@
+package in.lazygod.controller;
+
+import in.lazygod.dto.GrantRightsRequest;
+import in.lazygod.enums.ResourceType;
+import in.lazygod.models.UserRights;
+import in.lazygod.service.UserRightsService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/rights")
+@SecurityRequirement(name = "bearer-key")
+@RequiredArgsConstructor
+public class RightsController {
+
+    private final UserRightsService userRightsService;
+
+    @PostMapping
+    public ResponseEntity<UserRights> grant(@RequestBody GrantRightsRequest request) {
+        return ResponseEntity.ok(userRightsService.grantRights(request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> revoke(@PathVariable("id") String id) {
+        userRightsService.revokeRights(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<UserRights>> list(@RequestParam String resourceId,
+                                                 @RequestParam ResourceType resourceType) {
+        return ResponseEntity.ok(userRightsService.listRights(resourceId, resourceType));
+    }
+}

--- a/src/main/java/in/lazygod/controller/UserController.java
+++ b/src/main/java/in/lazygod/controller/UserController.java
@@ -1,6 +1,7 @@
 package in.lazygod.controller;
 
 import in.lazygod.models.User;
+import in.lazygod.dto.UserUpdateRequest;
 import in.lazygod.security.SecurityContextHolderUtil;
 import in.lazygod.service.UserService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -37,5 +38,10 @@ public class UserController {
         boolean success = userService.disconnect(username);
 
         return success ? ResponseEntity.accepted().build() : ResponseEntity.badRequest().build();
+    }
+
+    @PatchMapping("/me")
+    public ResponseEntity<User> updateProfile(@RequestBody UserUpdateRequest request) {
+        return ResponseEntity.ok(userService.updateProfile(request));
     }
 }

--- a/src/main/java/in/lazygod/dto/GrantRightsRequest.java
+++ b/src/main/java/in/lazygod/dto/GrantRightsRequest.java
@@ -1,0 +1,13 @@
+package in.lazygod.dto;
+
+import in.lazygod.enums.FileRights;
+import in.lazygod.enums.ResourceType;
+import lombok.Data;
+
+@Data
+public class GrantRightsRequest {
+    private String username;
+    private String resourceId;
+    private ResourceType resourceType;
+    private FileRights rightsType;
+}

--- a/src/main/java/in/lazygod/dto/UserUpdateRequest.java
+++ b/src/main/java/in/lazygod/dto/UserUpdateRequest.java
@@ -1,0 +1,9 @@
+package in.lazygod.dto;
+
+import lombok.Data;
+
+@Data
+public class UserUpdateRequest {
+    private String email;
+    private String fullName;
+}

--- a/src/main/java/in/lazygod/repositories/UserRightsRepository.java
+++ b/src/main/java/in/lazygod/repositories/UserRightsRepository.java
@@ -19,6 +19,8 @@ public interface UserRightsRepository extends JpaRepository<UserRights, String> 
 
     List<UserRights> findAllByFileIdAndResourceType(String fileId, ResourceType resourceType);
 
+    List<UserRights> findAllByParentFolderIdAndResourceType(String parentFolderId, ResourceType resourceType);
+
     Page<UserRights> findAllByUserIdAndParentFolderIdAndResourceType(
             String userId,
             String parentFolderId,

--- a/src/main/java/in/lazygod/service/UserRightsService.java
+++ b/src/main/java/in/lazygod/service/UserRightsService.java
@@ -1,0 +1,72 @@
+package in.lazygod.service;
+
+import in.lazygod.dto.GrantRightsRequest;
+import in.lazygod.enums.FileRights;
+import in.lazygod.enums.ResourceType;
+import in.lazygod.models.User;
+import in.lazygod.models.UserRights;
+import in.lazygod.repositories.UserRepository;
+import in.lazygod.repositories.UserRightsRepository;
+import in.lazygod.security.SecurityContextHolderUtil;
+import in.lazygod.util.SnowflakeIdGenerator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserRightsService {
+
+    private final UserRightsRepository rightsRepository;
+    private final UserRepository userRepository;
+    private final SnowflakeIdGenerator idGenerator;
+
+    @Transactional
+    public UserRights grantRights(GrantRightsRequest request) {
+        User current = SecurityContextHolderUtil.getCurrentUser();
+
+        // Only admins can grant rights
+        if (!current.getRole().name().equals("ROLE_ADMIN")) {
+            throw new in.lazygod.exception.ForbiddenException("not.authorized");
+        }
+
+        User target = userRepository.findByUsername(request.getUsername())
+                .orElseThrow(() -> new in.lazygod.exception.NotFoundException("user.not.found"));
+
+        UserRights rights = UserRights.builder()
+                .urId(idGenerator.nextId())
+                .userId(target.getUserId())
+                .rightsType(request.getRightsType())
+                .resourceType(request.getResourceType())
+                .createdOn(LocalDateTime.now())
+                .updatedOn(LocalDateTime.now())
+                .isActive(true)
+                .isFavourite(false)
+                .build();
+
+        if (request.getResourceType() == ResourceType.FILE) {
+            rights.setFileId(request.getResourceId());
+        } else {
+            rights.setParentFolderId(request.getResourceId());
+        }
+
+        return rightsRepository.save(rights);
+    }
+
+    @Transactional
+    public void revokeRights(String urId) {
+        rightsRepository.deleteById(urId);
+    }
+
+    public List<UserRights> listRights(String resourceId, ResourceType type) {
+        if (type == ResourceType.FILE) {
+            return rightsRepository.findAllByFileIdAndResourceType(resourceId, ResourceType.FILE);
+        }
+        return rightsRepository.findAllByParentFolderIdAndResourceType(resourceId, ResourceType.FOLDER);
+    }
+}

--- a/src/main/java/in/lazygod/service/UserService.java
+++ b/src/main/java/in/lazygod/service/UserService.java
@@ -7,6 +7,7 @@ import in.lazygod.models.User;
 import in.lazygod.repositories.ConnectionRepository;
 import in.lazygod.repositories.UserRepository;
 import in.lazygod.security.SecurityContextHolderUtil;
+import in.lazygod.dto.UserUpdateRequest;
 import in.lazygod.websocket.handlers.NotificationHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -60,5 +61,17 @@ public class UserService {
         NotificationHandler.send(receipent.getUsername(), current.getUsername(), "connection-rejected", null);
 
         return true;
+    }
+
+    public User updateProfile(UserUpdateRequest request) {
+        User current = SecurityContextHolderUtil.getCurrentUser();
+        if (request.getEmail() != null) {
+            current.setEmail(request.getEmail());
+        }
+        if (request.getFullName() != null) {
+            current.setFullName(request.getFullName());
+        }
+        current.setUpdatedOn(LocalDateTime.now());
+        return userRepository.save(current);
     }
 }


### PR DESCRIPTION
## Summary
- log all REST API entry/exit and duration via AOP
- expose PATCH `/users/me` to update profile
- expose `/rights` endpoints to manage file/folder rights
- add DTOs and service for rights management
- add AOP dependency

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6887e0dd61a48330819bb172b7a011d0