### PR TITLE
Enhance rights controller

### DIFF
--- a/src/main/java/in/lazygod/controller/RightsController.java
+++ b/src/main/java/in/lazygod/controller/RightsController.java
@@ -3,6 +3,7 @@ package in.lazygod.controller;
 import in.lazygod.dto.GrantRightsRequest;
 import in.lazygod.enums.ResourceType;
 import in.lazygod.models.UserRights;
+import in.lazygod.dto.RightsInfo;
 import in.lazygod.service.UserRightsService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
@@ -24,14 +25,15 @@ public class RightsController {
         return ResponseEntity.ok(userRightsService.grantRights(request));
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> revoke(@PathVariable("id") String id) {
-        userRightsService.revokeRights(id);
+    @DeleteMapping
+    public ResponseEntity<Void> revoke(@RequestParam String resourceId,
+                                       @RequestParam ResourceType resourceType) {
+        userRightsService.revokeRights(resourceId, resourceType);
         return ResponseEntity.noContent().build();
     }
 
     @GetMapping
-    public ResponseEntity<List<UserRights>> list(@RequestParam String resourceId,
+    public ResponseEntity<List<RightsInfo>> list(@RequestParam String resourceId,
                                                  @RequestParam ResourceType resourceType) {
         return ResponseEntity.ok(userRightsService.listRights(resourceId, resourceType));
     }

--- a/src/main/java/in/lazygod/dto/RightsInfo.java
+++ b/src/main/java/in/lazygod/dto/RightsInfo.java
@@ -1,0 +1,20 @@
+package in.lazygod.dto;
+
+import in.lazygod.enums.FileRights;
+import in.lazygod.enums.ResourceType;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class RightsInfo {
+    private String urId;
+    private String userId;
+    private String username;
+    private String fullName;
+    private String email;
+    private String fileId;
+    private String parentFolderId;
+    private FileRights rightsType;
+    private ResourceType resourceType;
+}

--- a/src/main/java/in/lazygod/service/UserRightsService.java
+++ b/src/main/java/in/lazygod/service/UserRightsService.java
@@ -5,6 +5,10 @@ import in.lazygod.enums.FileRights;
 import in.lazygod.enums.ResourceType;
 import in.lazygod.models.User;
 import in.lazygod.models.UserRights;
+import in.lazygod.models.File;
+import in.lazygod.models.Folder;
+import in.lazygod.repositories.FileRepository;
+import in.lazygod.repositories.FolderRepository;
 import in.lazygod.repositories.UserRepository;
 import in.lazygod.repositories.UserRightsRepository;
 import in.lazygod.security.SecurityContextHolderUtil;
@@ -25,12 +29,13 @@ public class UserRightsService {
     private final UserRightsRepository rightsRepository;
     private final UserRepository userRepository;
     private final SnowflakeIdGenerator idGenerator;
+    private final FileRepository fileRepository;
+    private final FolderRepository folderRepository;
 
     @Transactional
     public UserRights grantRights(GrantRightsRequest request) {
         User current = SecurityContextHolderUtil.getCurrentUser();
 
-        // Only admins can grant rights
         if (!current.getRole().name().equals("ROLE_ADMIN")) {
             throw new in.lazygod.exception.ForbiddenException("not.authorized");
         }
@@ -38,35 +43,132 @@ public class UserRightsService {
         User target = userRepository.findByUsername(request.getUsername())
                 .orElseThrow(() -> new in.lazygod.exception.NotFoundException("user.not.found"));
 
+        if (request.getResourceType() == ResourceType.FILE) {
+            File file = fileRepository.findById(request.getResourceId())
+                    .orElseThrow(() -> new in.lazygod.exception.NotFoundException("resource.not.found"));
+            String parent = file.getParentFolder() == null ? null : file.getParentFolder().getFolderId();
+            String parentForUser = determineParentFolder(target, parent);
+            return applyFileRights(target, file, parentForUser, request.getRightsType());
+        } else {
+            Folder folder = folderRepository.findById(request.getResourceId())
+                    .orElseThrow(() -> new in.lazygod.exception.NotFoundException("resource.not.found"));
+            String parent = folder.getParentFolder() == null ? null : folder.getParentFolder().getFolderId();
+            String parentForUser = determineParentFolder(target, parent);
+            applyFolderRightsRecursive(target, folder, parentForUser, request.getRightsType());
+            return rightsRepository.findByUserIdAndParentFolderId(target.getUserId(), folder.getFolderId())
+                    .orElseThrow();
+        }
+    }
+
+    @Transactional
+    public void revokeRights(String resourceId, ResourceType type) {
+        User current = SecurityContextHolderUtil.getCurrentUser();
+        if (type == ResourceType.FILE) {
+            rightsRepository.findByUserIdAndFileIdAndResourceType(current.getUserId(), resourceId, ResourceType.FILE)
+                    .ifPresent(rightsRepository::delete);
+        } else {
+            rightsRepository.findByUserIdAndParentFolderId(current.getUserId(), resourceId)
+                    .ifPresent(rightsRepository::delete);
+        }
+    }
+
+    public List<RightsInfo> listRights(String resourceId, ResourceType type) {
+        List<UserRights> rights;
+        if (type == ResourceType.FILE) {
+            rights = rightsRepository.findAllByFileIdAndResourceType(resourceId, ResourceType.FILE);
+        } else {
+            rights = rightsRepository.findAllByParentFolderIdAndResourceType(resourceId, ResourceType.FOLDER);
+        }
+
+        return rights.stream().map(r -> {
+            User u = userRepository.findById(r.getUserId()).orElse(null);
+            return new RightsInfo(
+                    r.getUrId(),
+                    r.getUserId(),
+                    u != null ? u.getUsername() : null,
+                    u != null ? u.getFullName() : null,
+                    u != null ? u.getEmail() : null,
+                    r.getFileId(),
+                    r.getParentFolderId(),
+                    r.getRightsType(),
+                    r.getResourceType()
+            );
+        }).toList();
+    }
+
+    private String determineParentFolder(User target, String parentFolderId) {
+        if (parentFolderId == null) {
+            return target.getUsername();
+        }
+        return rightsRepository.findByUserIdAndParentFolderId(target.getUserId(), parentFolderId)
+                .or(() -> rightsRepository.findByUserIdAndFileIdAndResourceType(target.getUserId(), parentFolderId, ResourceType.FOLDER))
+                .isPresent() ? parentFolderId : target.getUsername();
+    }
+
+    private FileRights higherRights(FileRights r1, FileRights r2) {
+        if (r1 == FileRights.ADMIN || r2 == FileRights.ADMIN) return FileRights.ADMIN;
+        if (r1 == FileRights.WRITE || r2 == FileRights.WRITE) return FileRights.WRITE;
+        return FileRights.READ;
+    }
+
+    private UserRights applyFileRights(User target, File file, String parentFolderId, FileRights rightsType) {
+        var existing = rightsRepository.findByUserIdAndFileIdAndResourceType(target.getUserId(), file.getFileId(), ResourceType.FILE);
+        if (existing.isPresent()) {
+            UserRights r = existing.get();
+            r.setParentFolderId(parentFolderId);
+            r.setRightsType(higherRights(r.getRightsType(), rightsType));
+            r.setUpdatedOn(LocalDateTime.now());
+            return rightsRepository.save(r);
+        }
+
         UserRights rights = UserRights.builder()
                 .urId(idGenerator.nextId())
                 .userId(target.getUserId())
-                .rightsType(request.getRightsType())
-                .resourceType(request.getResourceType())
+                .fileId(file.getFileId())
+                .parentFolderId(parentFolderId)
+                .rightsType(rightsType)
+                .resourceType(ResourceType.FILE)
                 .createdOn(LocalDateTime.now())
                 .updatedOn(LocalDateTime.now())
                 .isActive(true)
                 .isFavourite(false)
                 .build();
-
-        if (request.getResourceType() == ResourceType.FILE) {
-            rights.setFileId(request.getResourceId());
-        } else {
-            rights.setParentFolderId(request.getResourceId());
-        }
-
         return rightsRepository.save(rights);
     }
 
-    @Transactional
-    public void revokeRights(String urId) {
-        rightsRepository.deleteById(urId);
-    }
-
-    public List<UserRights> listRights(String resourceId, ResourceType type) {
-        if (type == ResourceType.FILE) {
-            return rightsRepository.findAllByFileIdAndResourceType(resourceId, ResourceType.FILE);
+    private void applyFolderRightsRecursive(User target, Folder folder, String parentFolderId, FileRights rightsType) {
+        var existing = rightsRepository.findByUserIdAndParentFolderId(target.getUserId(), folder.getFolderId());
+        UserRights currentRights;
+        if (existing.isPresent()) {
+            currentRights = existing.get();
+            currentRights.setRightsType(higherRights(currentRights.getRightsType(), rightsType));
+            currentRights.setUpdatedOn(LocalDateTime.now());
+        } else {
+            currentRights = UserRights.builder()
+                    .urId(idGenerator.nextId())
+                    .userId(target.getUserId())
+                    .fileId(folder.getFolderId())
+                    .parentFolderId(folder.getFolderId())
+                    .rightsType(rightsType)
+                    .resourceType(ResourceType.FOLDER)
+                    .createdOn(LocalDateTime.now())
+                    .updatedOn(LocalDateTime.now())
+                    .isActive(true)
+                    .isFavourite(false)
+                    .build();
         }
-        return rightsRepository.findAllByParentFolderIdAndResourceType(resourceId, ResourceType.FOLDER);
+        rightsRepository.save(currentRights);
+
+        // apply for sub files
+        List<File> files = fileRepository.findByParentFolder(folder);
+        for (File f : files) {
+            applyFileRights(target, f, folder.getFolderId(), rightsType);
+        }
+
+        // recurse for subfolders
+        List<Folder> children = folderRepository.findByParentFolder(folder);
+        for (Folder child : children) {
+            applyFolderRightsRecursive(target, child, folder.getFolderId(), rightsType);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add new `RightsInfo` DTO to include user details when listing rights
- expand `UserRightsService` to handle recursive folder rights and higher-rights logic
- adjust revoke API to delete by resource and user
- return user info when listing rights

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6887e648c1a8833081760897142b750e