### PR TITLE
Add Java SDK for API

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,3 +77,21 @@ Database credentials can be tweaked via the `DB_*` environment variables in
 
 - Collaborative editing through Collabora Online integration.
 - File versioning with configurable retention per storage.
+
+---
+
+## 📚 SDK
+
+A lightweight Java SDK is available under the [`sdk`](sdk) directory. It targets **Java 17** and offers helper classes to authenticate with the API, make HTTP requests and work with the WebSocket endpoint.
+
+Example usage:
+
+```java
+var sdk = new in.lazygod.sdk.FileManagerSDK("http://localhost:8080", "user", "pass");
+String me = sdk.get("/users/me");
+
+sdk.connectWebSocket();
+sdk.registerWebSocketHandler("notification", payload -> System.out.println(payload));
+```
+
+The SDK also exposes helpers to refresh tokens automatically when API calls return 401.

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -1,0 +1,19 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>in.lazygod</groupId>
+    <artifactId>filemanager-sdk</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.17.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/sdk/src/main/java/in/lazygod/sdk/AuthTokens.java
+++ b/sdk/src/main/java/in/lazygod/sdk/AuthTokens.java
@@ -1,0 +1,25 @@
+package in.lazygod.sdk;
+
+/**
+ * Simple holder for authentication tokens returned by the File Manager API.
+ */
+public class AuthTokens {
+    private String accessToken;
+    private String refreshTooken; // intentionally spelled as in server response
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getRefreshTooken() {
+        return refreshTooken;
+    }
+
+    public void setRefreshTooken(String refreshTooken) {
+        this.refreshTooken = refreshTooken;
+    }
+}

--- a/sdk/src/main/java/in/lazygod/sdk/FileManagerSDK.java
+++ b/sdk/src/main/java/in/lazygod/sdk/FileManagerSDK.java
@@ -1,0 +1,126 @@
+package in.lazygod.sdk;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import in.lazygod.sdk.ws.Packet;
+import in.lazygod.sdk.ws.WebSocketClient;
+import in.lazygod.sdk.ws.WebSocketMessageHandler;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * Minimal SDK for interacting with the File Manager server.
+ */
+public class FileManagerSDK {
+
+    private final String baseUrl;
+    private final String username;
+    private final String password;
+    private final HttpClient httpClient;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private AuthTokens tokens;
+    private WebSocketClient wsClient;
+
+    public FileManagerSDK(String baseUrl, String username, String password) throws IOException, InterruptedException {
+        this.baseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+        this.username = username;
+        this.password = password;
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+        login();
+    }
+
+    /**
+     * Authenticate using username/password and store the tokens.
+     */
+    public void login() throws IOException, InterruptedException {
+        Map<String, String> body = Map.of(
+                "username", username,
+                "password", password
+        );
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + "/auth/login"))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(body)))
+                .build();
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() >= 200 && response.statusCode() < 300) {
+            tokens = mapper.readValue(response.body(), AuthTokens.class);
+        } else {
+            throw new IOException("Authentication failed with status " + response.statusCode());
+        }
+    }
+
+    /** Refresh access token using the refresh token. */
+    public void refresh() throws IOException, InterruptedException {
+        if (tokens == null) return;
+        Map<String, String> body = Map.of("refreshToken", tokens.getRefreshTooken());
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + "/auth/refresh"))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(body)))
+                .build();
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() >= 200 && response.statusCode() < 300) {
+            tokens = mapper.readValue(response.body(), AuthTokens.class);
+        } else {
+            throw new IOException("Token refresh failed with status " + response.statusCode());
+        }
+    }
+
+    /** Perform a GET request to the given path. */
+    public String get(String path) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + path))
+                .header("Authorization", "Bearer " + tokens.getAccessToken())
+                .GET()
+                .build();
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() == 401) {
+            refresh();
+            return get(path);
+        }
+        return response.body();
+    }
+
+    /** Perform a POST request with JSON body. */
+    public String post(String path, Object payload) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + path))
+                .header("Authorization", "Bearer " + tokens.getAccessToken())
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(payload)))
+                .build();
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() == 401) {
+            refresh();
+            return post(path, payload);
+        }
+        return response.body();
+    }
+
+    /** Connect to websocket and request available features. */
+    public void connectWebSocket() throws Exception {
+        if (wsClient != null) return;
+        wsClient = new WebSocketClient();
+        String wsUri = baseUrl.replaceFirst("^http", "ws") + "/ws?token=" + tokens.getAccessToken();
+        wsClient.connect(wsUri).join();
+        Packet featureReq = new Packet();
+        featureReq.type = "features";
+        featureReq.to = "system";
+        featureReq.from = username;
+        wsClient.send(featureReq);
+    }
+
+    /** Register websocket handler for a specific message type. */
+    public void registerWebSocketHandler(String type, WebSocketMessageHandler handler) {
+        if (wsClient != null) wsClient.registerHandler(type, handler);
+    }
+}

--- a/sdk/src/main/java/in/lazygod/sdk/ws/Packet.java
+++ b/sdk/src/main/java/in/lazygod/sdk/ws/Packet.java
@@ -1,0 +1,13 @@
+package in.lazygod.sdk.ws;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * DTO for websocket packets.
+ */
+public class Packet {
+    public String type;
+    public String to;
+    public String from;
+    public JsonNode payload;
+}

--- a/sdk/src/main/java/in/lazygod/sdk/ws/WebSocketClient.java
+++ b/sdk/src/main/java/in/lazygod/sdk/ws/WebSocketClient.java
@@ -1,0 +1,75 @@
+package in.lazygod.sdk.ws;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.net.http.WebSocket.Listener;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Lightweight WebSocket client for communicating with the File Manager server.
+ */
+public class WebSocketClient implements Listener {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final Map<String, WebSocketMessageHandler> handlers = new ConcurrentHashMap<>();
+    private WebSocket webSocket;
+
+    /** Connect to the given websocket URI. */
+    public CompletableFuture<Void> connect(String uri) {
+        HttpClient client = HttpClient.newHttpClient();
+        return client.newWebSocketBuilder()
+                .buildAsync(URI.create(uri), this)
+                .thenAccept(ws -> this.webSocket = ws);
+    }
+
+    /** Send a packet. */
+    public void send(Packet packet) throws JsonProcessingException {
+        if (webSocket != null) {
+            String text = mapper.writeValueAsString(packet);
+            webSocket.sendText(text, true);
+        }
+    }
+
+    /** Register a handler for a specific packet type. */
+    public void registerHandler(String type, WebSocketMessageHandler handler) {
+        handlers.put(type, handler);
+    }
+
+    @Override
+    public void onOpen(WebSocket webSocket) {
+        Listener.super.onOpen(webSocket);
+        this.webSocket = webSocket;
+    }
+
+    @Override
+    public CompletionStage<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+        try {
+            Packet packet = mapper.readValue(data.toString(), Packet.class);
+            WebSocketMessageHandler handler = handlers.get(packet.type);
+            if (handler != null && packet.payload != null) {
+                handler.handle(packet.payload);
+            }
+        } catch (Exception ignore) {
+        }
+        return Listener.super.onText(webSocket, data, last);
+    }
+
+    @Override
+    public CompletionStage<?> onBinary(WebSocket webSocket, ByteBuffer data, boolean last) {
+        return Listener.super.onBinary(webSocket, data, last);
+    }
+
+    @Override
+    public void onError(WebSocket webSocket, Throwable error) {
+        Listener.super.onError(webSocket, error);
+    }
+}

--- a/sdk/src/main/java/in/lazygod/sdk/ws/WebSocketMessageHandler.java
+++ b/sdk/src/main/java/in/lazygod/sdk/ws/WebSocketMessageHandler.java
@@ -1,0 +1,11 @@
+package in.lazygod.sdk.ws;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Functional interface for handling websocket messages for a specific type.
+ */
+@FunctionalInterface
+public interface WebSocketMessageHandler {
+    void handle(JsonNode payload);
+}


### PR DESCRIPTION
## Summary
- introduce `sdk` module providing a Java 17 helper library
- add classes for authentication, HTTP helpers and WebSocket usage
- document SDK usage in the README

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve spring-boot-starter-parent)*
- `mvn -q -e -DskipTests package` in `sdk` *(fails: Could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6888ea6da62c8330abf980b718ffa132