### PR TITLE
Add Java SDK skeleton

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,0 +1,14 @@
+# File Manager Java SDK
+
+This module provides a lightweight client for the File Manager API. It handles
+authentication, HTTP requests and WebSocket connectivity.
+
+Features include:
+
+- Login with automatic token refresh
+- Simple REST helper methods
+- WebSocket client with pluggable message handlers
+- Automatic activation of handlers based on server supported features
+
+The SDK targets **Java 17** and uses only the JDK HTTP and WebSocket APIs plus
+Jackson for JSON mapping.

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>in.lazygod</groupId>
+    <artifactId>filemanager-sdk</artifactId>
+    <version>0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.17.1</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/sdk/src/main/java/in/lazygod/sdk/FileSyncClient.java
+++ b/sdk/src/main/java/in/lazygod/sdk/FileSyncClient.java
@@ -1,0 +1,76 @@
+package in.lazygod.sdk;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import in.lazygod.sdk.handlers.PacketHandler;
+import in.lazygod.sdk.ws.Packet;
+import in.lazygod.sdk.ws.WebSocketClient;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+public class FileSyncClient {
+    private final String baseUrl;
+    private final HttpClient client;
+    private final TokenManager tokenManager;
+    private WebSocketClient wsClient;
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final Set<String> features = new HashSet<>();
+
+    private FileSyncClient(String baseUrl, String username, String password) {
+        this.baseUrl = baseUrl;
+        this.client = HttpClient.newHttpClient();
+        this.tokenManager = new TokenManager(baseUrl, username, password);
+    }
+
+    public static Builder builder() { return new Builder(); }
+
+    public String get(String path) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + path))
+                .header("Authorization", "Bearer " + tokenManager.getAccessToken())
+                .GET()
+                .build();
+        HttpResponse<String> resp = client.send(request, HttpResponse.BodyHandlers.ofString());
+        if (resp.statusCode() >= 200 && resp.statusCode() < 300) {
+            return resp.body();
+        }
+        throw new RuntimeException("Request failed: " + resp.statusCode());
+    }
+
+    public CompletableFuture<Void> connectWebSocket() throws IOException, InterruptedException {
+        wsClient = new WebSocketClient(baseUrl.replaceFirst("http", "ws") + "/ws");
+        wsClient.registerHandler("features", (packet, payload) -> {
+            if (payload.isArray()) {
+                payload.forEach(n -> features.add(n.asText()));
+            }
+        });
+        return wsClient.connect(tokenManager.getAccessToken());
+    }
+
+    public void registerHandler(String type, PacketHandler handler) {
+        if (wsClient != null && features.contains(type)) {
+            wsClient.registerHandler(type, handler);
+        }
+    }
+
+    public static class Builder {
+        private String baseUrl;
+        private String username;
+        private String password;
+
+        public Builder baseUrl(String url) { this.baseUrl = url; return this; }
+        public Builder username(String u) { this.username = u; return this; }
+        public Builder password(String p) { this.password = p; return this; }
+
+        public FileSyncClient build() {
+            return new FileSyncClient(baseUrl, username, password);
+        }
+    }
+}

--- a/sdk/src/main/java/in/lazygod/sdk/TokenManager.java
+++ b/sdk/src/main/java/in/lazygod/sdk/TokenManager.java
@@ -1,0 +1,82 @@
+package in.lazygod.sdk;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import in.lazygod.sdk.dto.AuthRequest;
+import in.lazygod.sdk.dto.AuthResponse;
+import in.lazygod.sdk.dto.RefreshTokenRequest;
+import in.lazygod.sdk.dto.RefreshTokenResponse;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Instant;
+
+public class TokenManager {
+    private final String baseUrl;
+    private final String username;
+    private final String password;
+    private final HttpClient client = HttpClient.newHttpClient();
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private String accessToken;
+    private String refreshToken;
+    private Instant expiresAt;
+
+    public TokenManager(String baseUrl, String username, String password) {
+        this.baseUrl = baseUrl;
+        this.username = username;
+        this.password = password;
+    }
+
+    public synchronized String getAccessToken() throws IOException, InterruptedException {
+        if (accessToken == null || Instant.now().isAfter(expiresAt)) {
+            if (refreshToken != null) {
+                refresh();
+            } else {
+                login();
+            }
+        }
+        return accessToken;
+    }
+
+    private void login() throws IOException, InterruptedException {
+        AuthRequest req = new AuthRequest(username, password);
+        String json = mapper.writeValueAsString(req);
+        HttpRequest http = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + "/auth/login"))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(json))
+                .build();
+        HttpResponse<String> resp = client.send(http, HttpResponse.BodyHandlers.ofString());
+        if (resp.statusCode() >= 200 && resp.statusCode() < 300) {
+            AuthResponse tokens = mapper.readValue(resp.body(), AuthResponse.class);
+            this.accessToken = tokens.getAccessToken();
+            this.refreshToken = tokens.getRefreshToken();
+            // crude expiration assumption: 14 minutes
+            this.expiresAt = Instant.now().plusSeconds(14 * 60);
+        } else {
+            throw new RuntimeException("Auth failed: " + resp.statusCode());
+        }
+    }
+
+    private void refresh() throws IOException, InterruptedException {
+        RefreshTokenRequest req = new RefreshTokenRequest(refreshToken);
+        String json = mapper.writeValueAsString(req);
+        HttpRequest http = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + "/auth/refresh"))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(json))
+                .build();
+        HttpResponse<String> resp = client.send(http, HttpResponse.BodyHandlers.ofString());
+        if (resp.statusCode() >= 200 && resp.statusCode() < 300) {
+            RefreshTokenResponse tokens = mapper.readValue(resp.body(), RefreshTokenResponse.class);
+            this.accessToken = tokens.getAccessToken();
+            this.refreshToken = tokens.getRefreshToken();
+            this.expiresAt = Instant.now().plusSeconds(14 * 60);
+        } else {
+            login();
+        }
+    }
+}

--- a/sdk/src/main/java/in/lazygod/sdk/dto/AuthRequest.java
+++ b/sdk/src/main/java/in/lazygod/sdk/dto/AuthRequest.java
@@ -1,0 +1,18 @@
+package in.lazygod.sdk.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AuthRequest {
+    @JsonProperty("username")
+    private String username;
+    @JsonProperty("password")
+    private String password;
+
+    public AuthRequest() {}
+    public AuthRequest(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+    public String getUsername() { return username; }
+    public String getPassword() { return password; }
+}

--- a/sdk/src/main/java/in/lazygod/sdk/dto/AuthResponse.java
+++ b/sdk/src/main/java/in/lazygod/sdk/dto/AuthResponse.java
@@ -1,0 +1,13 @@
+package in.lazygod.sdk.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AuthResponse {
+    @JsonProperty("accessToken")
+    private String accessToken;
+    @JsonProperty("refreshTooken")
+    private String refreshToken;
+
+    public String getAccessToken() { return accessToken; }
+    public String getRefreshToken() { return refreshToken; }
+}

--- a/sdk/src/main/java/in/lazygod/sdk/dto/RefreshTokenRequest.java
+++ b/sdk/src/main/java/in/lazygod/sdk/dto/RefreshTokenRequest.java
@@ -1,0 +1,12 @@
+package in.lazygod.sdk.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class RefreshTokenRequest {
+    @JsonProperty("refreshToken")
+    private String refreshToken;
+
+    public RefreshTokenRequest() {}
+    public RefreshTokenRequest(String refreshToken) { this.refreshToken = refreshToken; }
+    public String getRefreshToken() { return refreshToken; }
+}

--- a/sdk/src/main/java/in/lazygod/sdk/dto/RefreshTokenResponse.java
+++ b/sdk/src/main/java/in/lazygod/sdk/dto/RefreshTokenResponse.java
@@ -1,0 +1,13 @@
+package in.lazygod.sdk.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class RefreshTokenResponse {
+    @JsonProperty("accessToken")
+    private String accessToken;
+    @JsonProperty("refreshToken")
+    private String refreshToken;
+
+    public String getAccessToken() { return accessToken; }
+    public String getRefreshToken() { return refreshToken; }
+}

--- a/sdk/src/main/java/in/lazygod/sdk/handlers/PacketHandler.java
+++ b/sdk/src/main/java/in/lazygod/sdk/handlers/PacketHandler.java
@@ -1,0 +1,9 @@
+package in.lazygod.sdk.handlers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import in.lazygod.sdk.ws.Packet;
+
+@FunctionalInterface
+public interface PacketHandler {
+    void handle(Packet packet, JsonNode payload);
+}

--- a/sdk/src/main/java/in/lazygod/sdk/ws/Packet.java
+++ b/sdk/src/main/java/in/lazygod/sdk/ws/Packet.java
@@ -1,0 +1,29 @@
+package in.lazygod.sdk.ws;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Packet {
+    @JsonProperty("type")
+    private String type;
+    @JsonProperty("to")
+    private String to;
+    @JsonProperty("from")
+    private String from;
+    @JsonProperty("payload")
+    private JsonNode payload;
+
+    public Packet() {}
+
+    public Packet(String type, JsonNode payload) {
+        this.type = type;
+        this.payload = payload;
+    }
+
+    public String getType() { return type; }
+    public String getTo() { return to; }
+    public String getFrom() { return from; }
+    public JsonNode getPayload() { return payload; }
+}

--- a/sdk/src/main/java/in/lazygod/sdk/ws/WebSocketClient.java
+++ b/sdk/src/main/java/in/lazygod/sdk/ws/WebSocketClient.java
@@ -1,0 +1,68 @@
+package in.lazygod.sdk.ws;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import in.lazygod.sdk.handlers.PacketHandler;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.net.http.WebSocket.Listener;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CompletionStage;
+
+public class WebSocketClient implements Listener {
+    private final URI uri;
+    private final HttpClient client;
+    private final ObjectMapper mapper = new ObjectMapper();
+    private WebSocket socket;
+    private final Map<String, PacketHandler> handlers = new ConcurrentHashMap<>();
+
+    public WebSocketClient(String uri) {
+        this.uri = URI.create(uri);
+        this.client = HttpClient.newHttpClient();
+    }
+
+    public CompletableFuture<Void> connect(String token) {
+        return client.newWebSocketBuilder()
+                .header("Authorization", "Bearer " + token)
+                .buildAsync(uri, this)
+                .thenAccept(ws -> this.socket = ws)
+                .thenRun(() -> send(new Packet("features", null)));
+    }
+
+    public void registerHandler(String type, PacketHandler handler) {
+        handlers.put(type, handler);
+    }
+
+    public void send(Packet packet) {
+        try {
+            String json = mapper.writeValueAsString(packet);
+            socket.sendText(json, true);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void onOpen(WebSocket webSocket) {
+        Listener.super.onOpen(webSocket);
+    }
+
+    @Override
+    public CompletionStage<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+        try {
+            Packet packet = mapper.readValue(data.toString(), Packet.class);
+            JsonNode payload = packet.getPayload();
+            PacketHandler handler = handlers.get(packet.getType());
+            if (handler != null) {
+                handler.handle(packet, payload);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return Listener.super.onText(webSocket, data, last);
+    }
+}


### PR DESCRIPTION
## Summary
- create `sdk` module with Maven config
- implement an initial `FileSyncClient` for REST and WebSocket usage
- add token management with automatic refresh
- include DTOs and basic WebSocket handler interface

## Testing
- `mvn -q -f sdk/pom.xml package` *(fails: PluginResolutionException due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6888ea6da62c8330abf980b718ffa132