### PR TITLE
Implement periodic cleanup

### DIFF
--- a/src/main/java/in/lazygod/FileManagerApplication.java
+++ b/src/main/java/in/lazygod/FileManagerApplication.java
@@ -16,12 +16,14 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
 
 @SpringBootApplication
+@EnableScheduling
 public class FileManagerApplication implements ApplicationRunner {
 
     public static Storage DEFAULT_STORAGE;

--- a/src/main/java/in/lazygod/service/CleanupService.java
+++ b/src/main/java/in/lazygod/service/CleanupService.java
@@ -1,0 +1,26 @@
+package in.lazygod.service;
+
+import in.lazygod.stoageUtils.StorageFactory;
+import in.lazygod.websocket.manager.UserSessionManager;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Scheduled maintenance tasks to keep the application tidy.
+ */
+@Component
+@Slf4j
+public class CleanupService {
+
+    /**
+     * Cleanup stale user sessions and expired cache entries.
+     * The interval can be tuned via the 'cleanup.interval.ms' property.
+     */
+    @Scheduled(fixedDelayString = "${cleanup.interval.ms:600000}")
+    public void runCleanup() {
+        UserSessionManager.getInstance().cleanupInactiveSessions();
+        StorageFactory.cleanExpired();
+        log.debug("cleanup completed");
+    }
+}

--- a/src/main/java/in/lazygod/stoageUtils/StorageFactory.java
+++ b/src/main/java/in/lazygod/stoageUtils/StorageFactory.java
@@ -68,4 +68,11 @@ public class StorageFactory {
         CACHE.put(key, new CachedEntry(impl));
         return impl;
     }
+
+    /**
+     * Remove expired cache entries.
+     */
+    public static void cleanExpired() {
+        CACHE.entrySet().removeIf(e -> e.getValue().expired());
+    }
 }

--- a/src/main/java/in/lazygod/websocket/manager/UserSessionManager.java
+++ b/src/main/java/in/lazygod/websocket/manager/UserSessionManager.java
@@ -63,6 +63,17 @@ public class UserSessionManager {
         if (wrapper != null) wrapper.send(packet);
     }
 
+    /**
+     * Remove closed WebSocket sessions and their users from memory.
+     * This prevents accumulation of stale sessions when clients
+     * disconnect unexpectedly.
+     */
+    public void cleanupInactiveSessions() {
+        SESSION_MAP.keySet().stream()
+                .filter(session -> !session.isOpen())
+                .forEach(this::close);
+    }
+
     private String extractToken(String query) {
         for (String param : query.split("&")) {
             if (param.startsWith("token=")) return param.substring(6);


### PR DESCRIPTION
## Summary
- enable scheduling on application startup
- clear expired StorageFactory entries
- remove stale websocket sessions
- add CleanupService scheduled task

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688a9ac6cc94833087913f6a91f69b88