### PR TITLE
Add admin UI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,12 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
+        <!-- Thymeleaf templating -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+
         <!-- WebSocket support -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/in/lazygod/admin/AdminController.java
+++ b/src/main/java/in/lazygod/admin/AdminController.java
@@ -1,0 +1,62 @@
+package in.lazygod.admin;
+
+import in.lazygod.models.User;
+import in.lazygod.repositories.UserRepository;
+import in.lazygod.stoageUtils.StorageFactory;
+import in.lazygod.websocket.manager.UserSessionManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+@Controller
+@RequestMapping("/admin")
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final UserRepository userRepository;
+
+    @GetMapping
+    public String index(Model model) {
+        model.addAttribute("users", userRepository.findAll());
+        model.addAttribute("wsSessions", UserSessionManager.getInstance().getActiveSessions());
+        model.addAttribute("metrics", AdminUtil.systemMetrics());
+        return "admin/index";
+    }
+
+    @PostMapping("/users/{id}/toggle")
+    public String toggleUser(@PathVariable("id") String id) {
+        userRepository.findById(id).ifPresent(user -> {
+            user.setActive(!user.isActive());
+            userRepository.save(user);
+        });
+        return "redirect:/admin";
+    }
+
+    @PostMapping("/cache/cleanup")
+    public String cleanupCache() {
+        StorageFactory.cleanExpired();
+        UserSessionManager.getInstance().cleanupInactiveSessions();
+        return "redirect:/admin";
+    }
+
+    @PostMapping("/ws/{sessionId}/close")
+    public String closeWs(@PathVariable String sessionId) {
+        UserSessionManager.getInstance().closeById(sessionId);
+        return "redirect:/admin";
+    }
+
+    @GetMapping("/logs")
+    public String logs(Model model) throws IOException {
+        model.addAttribute("logLines", AdminUtil.tailLog(Path.of("logs/application.log"), 200));
+        return "admin/logs";
+    }
+
+    @GetMapping("/login")
+    public String login() {
+        return "admin/login";
+    }
+}

--- a/src/main/java/in/lazygod/admin/AdminUtil.java
+++ b/src/main/java/in/lazygod/admin/AdminUtil.java
@@ -1,0 +1,30 @@
+package in.lazygod.admin;
+
+import com.sun.management.OperatingSystemMXBean;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AdminUtil {
+
+    public static Map<String, Object> systemMetrics() {
+        Map<String, Object> map = new HashMap<>();
+        Runtime rt = Runtime.getRuntime();
+        map.put("memUsed", rt.totalMemory() - rt.freeMemory());
+        map.put("memTotal", rt.totalMemory());
+        OperatingSystemMXBean osBean = (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
+        map.put("cpuLoad", String.format("%.2f", osBean.getSystemCpuLoad() * 100));
+        return map;
+    }
+
+    public static List<String> tailLog(Path path, int lines) throws IOException {
+        if (!Files.exists(path)) return List.of();
+        List<String> all = Files.readAllLines(path);
+        int start = Math.max(0, all.size() - lines);
+        return all.subList(start, all.size());
+    }
+}

--- a/src/main/java/in/lazygod/config/AdminServerConfig.java
+++ b/src/main/java/in/lazygod/config/AdminServerConfig.java
@@ -1,0 +1,26 @@
+package in.lazygod.config;
+
+import org.apache.catalina.connector.Connector;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AdminServerConfig {
+
+    @Value("${admin.server.port:0}")
+    private int adminPort;
+
+    @Bean
+    public ServletWebServerFactory servletContainer() {
+        TomcatServletWebServerFactory factory = new TomcatServletWebServerFactory();
+        if (adminPort > 0 && adminPort != factory.getPort()) {
+            Connector connector = new Connector(TomcatServletWebServerFactory.DEFAULT_PROTOCOL);
+            connector.setPort(adminPort);
+            factory.addAdditionalTomcatConnectors(connector);
+        }
+        return factory;
+    }
+}

--- a/src/main/java/in/lazygod/config/SecurityConfig.java
+++ b/src/main/java/in/lazygod/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package in.lazygod.config;
 
 import in.lazygod.security.CustomAuthenticationEntryPoint;
 import in.lazygod.security.JwtAuthenticationFilter;
+import in.lazygod.security.UserDetailsServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,6 +16,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.core.annotation.Order;
 
 @Configuration
 @RequiredArgsConstructor
@@ -25,13 +27,31 @@ public class SecurityConfig {
 
     private final CustomAuthenticationEntryPoint authEntryPoint;
 
+    private final UserDetailsServiceImpl userDetailsService;
+
     @Bean
+    @Order(1)
+    public SecurityFilterChain adminFilterChain(HttpSecurity http) throws Exception {
+        return http.securityMatcher("/admin/**")
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/admin/login").permitAll()
+                        .anyRequest().hasRole("ADMIN")
+                )
+                .userDetailsService(userDetailsService)
+                .formLogin(form -> form.loginPage("/admin/login").defaultSuccessUrl("/admin", true))
+                .logout(logout -> logout.logoutUrl("/admin/logout").logoutSuccessUrl("/admin/login"))
+                .csrf(AbstractHttpConfigurer::disable)
+                .build();
+    }
+
+    @Bean
+    @Order(2)
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http.csrf(AbstractHttpConfigurer::disable)
                 .cors(cors -> cors.configurationSource(request -> {
                     var corsConfig = new org.springframework.web.cors.CorsConfiguration();
                     corsConfig.setAllowCredentials(true);
-                    corsConfig.addAllowedOriginPattern("*"); // allow all origins
+                    corsConfig.addAllowedOriginPattern("*");
                     corsConfig.addAllowedHeader("*");
                     corsConfig.addAllowedMethod("*");
                     return corsConfig;

--- a/src/main/java/in/lazygod/websocket/manager/UserSessionManager.java
+++ b/src/main/java/in/lazygod/websocket/manager/UserSessionManager.java
@@ -9,6 +9,8 @@ import org.springframework.web.socket.WebSocketSession;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.HashMap;
+import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -61,6 +63,28 @@ public class UserSessionManager {
     public void sendToUser(String username, Packet packet) {
         UserWrapper wrapper = USERS.get(username);
         if (wrapper != null) wrapper.send(packet);
+    }
+
+    public Map<String, String> getActiveSessions() {
+        Map<String, String> map = new HashMap<>();
+        SESSION_MAP.forEach((session, wrapper) -> {
+            if (wrapper.getUserWrapper() != null) {
+                map.put(session.getId(), wrapper.getUserWrapper().getUsername());
+            }
+        });
+        return map;
+    }
+
+    public void closeById(String sessionId) {
+        SESSION_MAP.keySet().stream()
+                .filter(s -> s.getId().equals(sessionId))
+                .findFirst()
+                .ifPresent(s -> {
+                    try {
+                        s.close();
+                    } catch (IOException ignored) {}
+                    close(s);
+                });
     }
 
     /**

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -36,5 +36,9 @@ system:
     email: admin@example.com
     password: admin123
 
+admin:
+  server:
+    port: 9090
+
 snowflake:
   node-id: 1

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,5 +49,9 @@ system:
     email: admin@example.com
     password: admin123
 
+admin:
+  server:
+    port: 9090
+
 snowflake:
   node-id: 1

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -4,7 +4,21 @@
 
     <logger name="in.lazygod" level="DEBUG" />
 
+    <property name="LOG_PATH" value="logs"/>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/application.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/application.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
     <root level="INFO">
         <appender-ref ref="CONSOLE" />
+        <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Admin Panel</title>
+</head>
+<body>
+<h1>Admin Panel</h1>
+
+<h2>System Metrics</h2>
+<p>Memory Used: <span th:text="${metrics.memUsed}"></span> / <span th:text="${metrics.memTotal}"></span></p>
+<p>CPU Load: <span th:text="${metrics.cpuLoad}"></span>%</p>
+
+<h2>Users</h2>
+<table border="1">
+    <tr><th>Username</th><th>Active</th><th>Action</th></tr>
+    <tr th:each="u : ${users}">
+        <td th:text="${u.username}"></td>
+        <td th:text="${u.active}"></td>
+        <td>
+            <form th:action="@{'/admin/users/' + ${u.userId} + '/toggle'}" method="post">
+                <button type="submit">Toggle</button>
+            </form>
+        </td>
+    </tr>
+</table>
+
+<h2>WebSocket Sessions</h2>
+<table border="1">
+    <tr><th>Session Id</th><th>User</th><th>Action</th></tr>
+    <tr th:each="ws : ${wsSessions}">
+        <td th:text="${ws.key}"></td>
+        <td th:text="${ws.value}"></td>
+        <td>
+            <form th:action="@{'/admin/ws/' + ${ws.key} + '/close'}" method="post">
+                <button type="submit">Close</button>
+            </form>
+        </td>
+    </tr>
+</table>
+
+<form th:action="@{/admin/cache/cleanup}" method="post">
+    <button type="submit">Cleanup Caches</button>
+</form>
+
+<p><a th:href="@{/admin/logs}">View Logs</a></p>
+<p><a th:href="@{/admin/logout}">Logout</a></p>
+</body>
+</html>

--- a/src/main/resources/templates/admin/login.html
+++ b/src/main/resources/templates/admin/login.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Admin Login</title>
+</head>
+<body>
+<h2>Admin Login</h2>
+<form th:action="@{/admin/login}" method="post">
+    <div>Username: <input type="text" name="username"/></div>
+    <div>Password: <input type="password" name="password"/></div>
+    <div><button type="submit">Login</button></div>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/admin/logs.html
+++ b/src/main/resources/templates/admin/logs.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Logs</title>
+</head>
+<body>
+<h2>Server Logs</h2>
+<pre th:text="${#strings.listJoin(logLines, '\n')}"></pre>
+<p><a th:href="@{/admin}">Back</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- include Thymeleaf dependency
- add rolling log file
- expose admin port via extra tomcat connector
- secure admin pages with form login
- implement admin controllers and utility helpers
- show metrics, users and websocket sessions
- clean caches, view logs and close sessions

## Testing
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688aa056fc80833080745684005620a5