### PR TITLE
Add AWS S3 presigned URL support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,13 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!-- AWS S3 SDK -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>2.25.60</version>
+        </dependency>
+
         <!-- Logging -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/readme.md
+++ b/readme.md
@@ -105,6 +105,22 @@ docker-compose -f docker-compose.dev.yml up -d
 - Storage configuration APIs
 - Java SDK skeleton for clients
 
+## 📖 Storage Setup
+
+You can attach AWS S3 buckets as additional storage locations.
+
+1. Send a `POST /storage` request with `storageType` set to `S3`. Use the bucket
+   name in `basePath` and provide your AWS credentials in `accessId` and
+   `accessKey`.
+2. Verify the credentials using `POST /storage/test`. This endpoint uploads and
+   deletes a temporary file to ensure the provided details work. It works for all
+   supported storage types.
+3. Grant users or groups access rights on the new storage via the rights APIs.
+
+Credentials are encrypted before being stored in the database. When using S3 the
+application generates presigned URLs so files are uploaded and downloaded
+directly from S3 without passing through the server.
+
 ## 🚧 In Pipeline
 
 - File and folder deletion endpoints

--- a/src/main/java/in/lazygod/FileManagerApplication.java
+++ b/src/main/java/in/lazygod/FileManagerApplication.java
@@ -10,6 +10,7 @@ import in.lazygod.repositories.StorageRepository;
 import in.lazygod.repositories.UserRepository;
 import in.lazygod.repositories.UserRightsRepository;
 import in.lazygod.security.JwtUtil;
+import in.lazygod.util.EncryptionUtil;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
@@ -80,12 +81,16 @@ public class FileManagerApplication implements ApplicationRunner {
     @Value("${jwt.expiration.hr}")
     private long jwtExpirationHr;
 
+    @Value("${encryption.secret}")
+    private String encryptionKey;
+
     @Override
     public void run(ApplicationArguments args) throws Exception {
 
         JwtUtil.SECRET_KEY = jwtKey;
         JwtUtil.EXPIRATION = jwtExpirationHr * 1000 * 60 * 60;
         JwtUtil.key = Keys.hmacShaKeyFor(JwtUtil.SECRET_KEY.getBytes());
+        EncryptionUtil.setSecret(encryptionKey);
 
         Optional<User> existing = userRepository.findByUsername(username);
 

--- a/src/main/java/in/lazygod/controller/StorageController.java
+++ b/src/main/java/in/lazygod/controller/StorageController.java
@@ -30,4 +30,13 @@ public class StorageController {
         var list = storageManagementService.listStorages();
         return ResponseEntity.ok(list);
     }
+
+    @PostMapping("/test")
+    public ResponseEntity<Void> test(@RequestBody Storage storage) {
+        boolean ok = storageManagementService.testCredentials(storage);
+        if (ok) {
+            return ResponseEntity.ok().build();
+        }
+        return ResponseEntity.badRequest().build();
+    }
 }

--- a/src/main/java/in/lazygod/converter/EncryptedStringConverter.java
+++ b/src/main/java/in/lazygod/converter/EncryptedStringConverter.java
@@ -1,0 +1,29 @@
+package in.lazygod.converter;
+
+import in.lazygod.util.EncryptionUtil;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class EncryptedStringConverter implements AttributeConverter<String, String> {
+    @Override
+    public String convertToDatabaseColumn(String attribute) {
+        if (attribute == null) return null;
+        try {
+            return EncryptionUtil.encrypt(attribute);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public String convertToEntityAttribute(String dbData) {
+        if (dbData == null) return null;
+        try {
+            return EncryptionUtil.decrypt(dbData);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/main/java/in/lazygod/models/Storage.java
+++ b/src/main/java/in/lazygod/models/Storage.java
@@ -2,6 +2,7 @@ package in.lazygod.models;
 
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import in.lazygod.converter.EncryptedStringConverter;
 import in.lazygod.enums.StorageType;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -44,8 +45,10 @@ public class Storage {
     private LocalDateTime updatedOn;
 
     @JsonIgnore
+    @Convert(converter = EncryptedStringConverter.class)
     private String accessKey;
 
     @JsonIgnore
+    @Convert(converter = EncryptedStringConverter.class)
     private String accessId;
 }

--- a/src/main/java/in/lazygod/service/StorageManagementService.java
+++ b/src/main/java/in/lazygod/service/StorageManagementService.java
@@ -12,4 +12,6 @@ public interface StorageManagementService {
     Storage createStorage(Storage storage);
 
     List<Storage> listStorages();
+
+    boolean testCredentials(Storage storage);
 }

--- a/src/main/java/in/lazygod/stoageUtils/S3Storage.java
+++ b/src/main/java/in/lazygod/stoageUtils/S3Storage.java
@@ -1,36 +1,150 @@
 package in.lazygod.stoageUtils;
 
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
-import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
 import java.io.IOException;
+import java.time.Duration;
 
 /**
- * Placeholder implementation for S3 storage. The actual AWS S3 integration
- * can be provided by wiring the AWS SDK and injecting an AmazonS3 client.
+ * AWS S3 based implementation for file storage. Supports both direct
+ * server-side uploads/downloads and generation of presigned URLs for
+ * clients to interact with S3 directly.
  */
-@Service
 public class S3Storage implements StorageImpl {
+
+    private final S3Client s3Client;
+    private final S3Presigner presigner;
+
+    public S3Storage(String accessId, String accessKey) {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessId, accessKey);
+        this.s3Client = S3Client.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .region(Region.US_EAST_1)
+                .serviceConfiguration(S3Configuration.builder()
+                        .checksumValidationEnabled(false)
+                        .build())
+                .build();
+
+        this.presigner = S3Presigner.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .region(Region.US_EAST_1)
+                .build();
+    }
+
+    private static String bucket(String path) {
+        int idx = path.indexOf('/');
+        return idx == -1 ? path : path.substring(0, idx);
+    }
+
+    private static String key(String path) {
+        int idx = path.indexOf('/');
+        return idx == -1 ? "" : path.substring(idx + 1);
+    }
 
     @Override
     public void upload(MultipartFile file, String destinationPath) throws IOException {
-        // TODO: integrate AWS SDK or other S3 compatible client
-        throw new UnsupportedOperationException("S3 upload not implemented");
+        String bucket = bucket(destinationPath);
+        String key = key(destinationPath);
+
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        s3Client.putObject(request, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
     }
 
     @Override
     public Resource download(String storagePath) throws IOException {
-        throw new UnsupportedOperationException("S3 download not implemented");
+        String bucket = bucket(storagePath);
+        String key = key(storagePath);
+
+        GetObjectRequest request = GetObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        try (var in = s3Client.getObject(request)) {
+            byte[] data = in.readAllBytes();
+            return new ByteArrayResource(data);
+        }
     }
 
     @Override
-    public void delete(String storagePath) throws IOException {
-        throw new UnsupportedOperationException("S3 delete not implemented");
+    public void delete(String storagePath) {
+        String bucket = bucket(storagePath);
+        String key = key(storagePath);
+
+        DeleteObjectRequest request = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        s3Client.deleteObject(request);
     }
 
     @Override
-    public boolean exists(String storagePath) throws IOException {
-        throw new UnsupportedOperationException("S3 exists not implemented");
+    public boolean exists(String storagePath) {
+        String bucket = bucket(storagePath);
+        String key = key(storagePath);
+
+        try {
+            HeadObjectRequest request = HeadObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build();
+            s3Client.headObject(request);
+            return true;
+        } catch (NoSuchKeyException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public String generatePresignedUploadUrl(String destinationPath, Duration expiry) {
+        String bucket = bucket(destinationPath);
+        String key = key(destinationPath);
+
+        PutObjectRequest objectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .putObjectRequest(objectRequest)
+                .signatureDuration(expiry)
+                .build();
+
+        return presigner.presignPutObject(presignRequest).url().toString();
+    }
+
+    @Override
+    public String generatePresignedDownloadUrl(String storagePath, Duration expiry) {
+        String bucket = bucket(storagePath);
+        String key = key(storagePath);
+
+        GetObjectRequest objectRequest = GetObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .getObjectRequest(objectRequest)
+                .signatureDuration(expiry)
+                .build();
+
+        return presigner.presignGetObject(presignRequest).url().toString();
     }
 }

--- a/src/main/java/in/lazygod/stoageUtils/StorageFactory.java
+++ b/src/main/java/in/lazygod/stoageUtils/StorageFactory.java
@@ -61,7 +61,7 @@ public class StorageFactory {
         StorageImpl impl;
         switch (config.getStorageType()) {
             case LOCAL -> impl = new LocalStorage(config.getBasePath());
-            case S3 -> impl = new S3Storage();
+            case S3 -> impl = new S3Storage(config.getAccessId(), config.getAccessKey());
             default -> impl = new DummyStorage();
         }
 

--- a/src/main/java/in/lazygod/stoageUtils/StorageImpl.java
+++ b/src/main/java/in/lazygod/stoageUtils/StorageImpl.java
@@ -41,4 +41,30 @@ public interface StorageImpl {
      * @return true if the file exists
      */
     boolean exists(String storagePath) throws IOException;
+
+    /**
+     * Generate a presigned URL for uploading a file directly to the storage
+     * backend. Implementations that do not support presigned URLs may throw
+     * {@link UnsupportedOperationException}.
+     *
+     * @param destinationPath relative path in the storage
+     * @param expiry          validity duration of the URL
+     * @return URL that clients can use to upload
+     */
+    default String generatePresignedUploadUrl(String destinationPath, java.time.Duration expiry) {
+        throw new UnsupportedOperationException("Presigned upload not supported");
+    }
+
+    /**
+     * Generate a presigned URL for downloading a file directly from the storage
+     * backend. Implementations that do not support presigned URLs may throw
+     * {@link UnsupportedOperationException}.
+     *
+     * @param storagePath relative path to the file in storage
+     * @param expiry      validity duration of the URL
+     * @return URL that clients can use to download
+     */
+    default String generatePresignedDownloadUrl(String storagePath, java.time.Duration expiry) {
+        throw new UnsupportedOperationException("Presigned download not supported");
+    }
 }

--- a/src/main/java/in/lazygod/util/EncryptionUtil.java
+++ b/src/main/java/in/lazygod/util/EncryptionUtil.java
@@ -1,0 +1,32 @@
+package in.lazygod.util;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Base64;
+
+public class EncryptionUtil {
+    private static String secret;
+
+    public static void setSecret(String key) {
+        secret = key;
+    }
+
+    private static Cipher cipher(int mode) throws Exception {
+        SecretKeySpec spec = new SecretKeySpec(secret.getBytes(), "AES");
+        Cipher c = Cipher.getInstance("AES");
+        c.init(mode, spec);
+        return c;
+    }
+
+    public static String encrypt(String plain) throws Exception {
+        Cipher c = cipher(Cipher.ENCRYPT_MODE);
+        byte[] enc = c.doFinal(plain.getBytes());
+        return Base64.getEncoder().encodeToString(enc);
+    }
+
+    public static String decrypt(String encrypted) throws Exception {
+        Cipher c = cipher(Cipher.DECRYPT_MODE);
+        byte[] dec = c.doFinal(Base64.getDecoder().decode(encrypted));
+        return new String(dec);
+    }
+}

--- a/src/main/java/in/lazygod/util/SimpleMultipartFile.java
+++ b/src/main/java/in/lazygod/util/SimpleMultipartFile.java
@@ -1,0 +1,70 @@
+package in.lazygod.util;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+
+/**
+ * Minimal {@link MultipartFile} implementation backed by a byte array.
+ */
+public class SimpleMultipartFile implements MultipartFile {
+    private final String name;
+    private final String originalFilename;
+    private final String contentType;
+    private final byte[] content;
+
+    public SimpleMultipartFile(String name, byte[] content) {
+        this(name, name, null, content);
+    }
+
+    public SimpleMultipartFile(String name, String originalFilename, String contentType, byte[] content) {
+        this.name = name;
+        this.originalFilename = originalFilename;
+        this.contentType = contentType;
+        this.content = content == null ? new byte[0] : content.clone();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getOriginalFilename() {
+        return originalFilename;
+    }
+
+    @Override
+    public String getContentType() {
+        return contentType;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return content.length == 0;
+    }
+
+    @Override
+    public long getSize() {
+        return content.length;
+    }
+
+    @Override
+    public byte[] getBytes() {
+        return content.clone();
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        return new ByteArrayInputStream(content);
+    }
+
+    @Override
+    public void transferTo(File dest) throws IOException, IllegalStateException {
+        Files.write(dest.toPath(), content);
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -38,3 +38,6 @@ system:
 
 snowflake:
   node-id: 1
+
+encryption:
+  secret: ChangeThisSecretKey123

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,3 +51,6 @@ system:
 
 snowflake:
   node-id: 1
+
+encryption:
+  secret: ChangeThisSecretKey123


### PR DESCRIPTION
## Summary
- implement S3 storage using AWS SDK with presigned URL helpers
- encrypt storage credentials using a JPA converter
- add credential test endpoint and update service layer
- expose new API in StorageController
- load encryption secret on startup
- document storage setup in README
- add AWS SDK dependency
- improve credential tests to work with any storage

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*


------
https://chatgpt.com/codex/tasks/task_e_688aa19d2a94833084456a3b9b404aec