### PR TITLE
Add simple rate limiting filter

### DIFF
--- a/src/main/java/in/lazygod/admin/AdminController.java
+++ b/src/main/java/in/lazygod/admin/AdminController.java
@@ -1,6 +1,7 @@
 package in.lazygod.admin;
 
 import in.lazygod.models.User;
+import in.lazygod.config.RateLimitProperties;
 import in.lazygod.repositories.UserRepository;
 import in.lazygod.stoageUtils.StorageFactory;
 import in.lazygod.websocket.manager.UserSessionManager;
@@ -18,12 +19,14 @@ import java.nio.file.Path;
 public class AdminController {
 
     private final UserRepository userRepository;
+    private final RateLimitProperties rateLimitProperties;
 
     @GetMapping
     public String index(Model model) {
         model.addAttribute("users", userRepository.findAll());
         model.addAttribute("wsSessions", UserSessionManager.getInstance().getActiveSessions());
         model.addAttribute("metrics", AdminUtil.systemMetrics());
+        model.addAttribute("rateLimitEnabled", rateLimitProperties.isEnabled());
         return "admin/index";
     }
 
@@ -46,6 +49,12 @@ public class AdminController {
     @PostMapping("/ws/{sessionId}/close")
     public String closeWs(@PathVariable String sessionId) {
         UserSessionManager.getInstance().closeById(sessionId);
+        return "redirect:/admin";
+    }
+
+    @PostMapping("/ratelimit/toggle")
+    public String toggleRateLimit() {
+        rateLimitProperties.setEnabled(!rateLimitProperties.isEnabled());
         return "redirect:/admin";
     }
 

--- a/src/main/java/in/lazygod/config/RateLimitProperties.java
+++ b/src/main/java/in/lazygod/config/RateLimitProperties.java
@@ -1,0 +1,13 @@
+package in.lazygod.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "ratelimit")
+public class RateLimitProperties {
+    private boolean enabled = true;
+    private int limit = 60; // requests per minute
+}

--- a/src/main/java/in/lazygod/filter/RateLimitFilter.java
+++ b/src/main/java/in/lazygod/filter/RateLimitFilter.java
@@ -1,0 +1,34 @@
+package in.lazygod.filter;
+
+import in.lazygod.service.RateLimitService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@Order(0)
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    private final RateLimitService rateLimitService;
+
+    public RateLimitFilter(RateLimitService rateLimitService) {
+        this.rateLimitService = rateLimitService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String key = request.getRemoteAddr();
+        if (!rateLimitService.isAllowed(key)) {
+            response.setStatus(HttpServletResponse.SC_TOO_MANY_REQUESTS);
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/in/lazygod/service/RateLimitService.java
+++ b/src/main/java/in/lazygod/service/RateLimitService.java
@@ -1,0 +1,43 @@
+package in.lazygod.service;
+
+import in.lazygod.config.RateLimitProperties;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class RateLimitService {
+
+    private final Map<String, RequestCounter> counters = new ConcurrentHashMap<>();
+    private final RateLimitProperties properties;
+
+    public RateLimitService(RateLimitProperties properties) {
+        this.properties = properties;
+    }
+
+    public boolean isAllowed(String key) {
+        if (!properties.isEnabled()) {
+            return true;
+        }
+        RequestCounter counter = counters.computeIfAbsent(key, k -> new RequestCounter());
+        synchronized (counter) {
+            long now = System.currentTimeMillis();
+            if (now - counter.timestamp > 60_000) {
+                counter.timestamp = now;
+                counter.count = 1;
+                return true;
+            }
+            if (counter.count >= properties.getLimit()) {
+                return false;
+            }
+            counter.count++;
+            return true;
+        }
+    }
+
+    private static class RequestCounter {
+        long timestamp = System.currentTimeMillis();
+        int count = 0;
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -45,3 +45,7 @@ snowflake:
 
 encryption:
   secret: ChangeThisSecretKey123
+
+ratelimit:
+  enabled: true
+  limit: 60

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,3 +58,7 @@ snowflake:
 
 encryption:
   secret: ChangeThisSecretKey123
+
+ratelimit:
+  enabled: true
+  limit: 60

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -42,6 +42,12 @@
     <button type="submit">Cleanup Caches</button>
 </form>
 
+<h2>Rate Limiting</h2>
+<p>Enabled: <span th:text="${rateLimitEnabled}"></span></p>
+<form th:action="@{/admin/ratelimit/toggle}" method="post">
+    <button type="submit">Toggle Rate Limit</button>
+</form>
+
 <p><a th:href="@{/admin/logs}">View Logs</a></p>
 <p><a th:href="@{/admin/logout}">Logout</a></p>
 </body>


### PR DESCRIPTION
## Summary
- introduce `RateLimitProperties` and default config
- implement `RateLimitService` and `RateLimitFilter`
- expose rate limit toggle in AdminController and template
- enable property in `application.yml` and `application-dev.yml`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688aa7913c5c8330be3fdd047f88896f