### PR TITLE
Improve chat history API and last-seen tracking

### DIFF
--- a/src/main/java/in/lazygod/models/User.java
+++ b/src/main/java/in/lazygod/models/User.java
@@ -44,6 +44,8 @@ public class User {
     @JsonIgnore
     private LocalDateTime updatedOn;
 
+    private LocalDateTime lastSeen;
+
     @JsonIgnore
     @Column(nullable = false)
     private String password; // hashed

--- a/src/main/java/in/lazygod/websocket/manager/LastSeenManager.java
+++ b/src/main/java/in/lazygod/websocket/manager/LastSeenManager.java
@@ -1,17 +1,33 @@
 package in.lazygod.websocket.manager;
 
+import in.lazygod.repositories.UserRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
+@Service
+@RequiredArgsConstructor
 public class LastSeenManager {
 
-    private final static LastSeenManager SEEN_MANAGER = new LastSeenManager();
+    private static LastSeenManager INSTANCE;
+
+    private final UserRepository userRepository;
 
     private final ConcurrentHashMap<String, Instant> LAST_SEEN = new ConcurrentHashMap<>();
 
+    @PostConstruct
+    private void init() {
+        INSTANCE = this;
+    }
+
     public static LastSeenManager getInstance(){
-        return SEEN_MANAGER;
+        return INSTANCE;
     }
 
     public void setOnline(String username){
@@ -19,10 +35,15 @@ public class LastSeenManager {
     }
 
     public void setOffline(String username){
-        LAST_SEEN.put(username,Instant.now());
+        Instant now = Instant.now();
+        LAST_SEEN.put(username, now);
+        userRepository.findByUsername(username).ifPresent(u -> {
+            u.setLastSeen(LocalDateTime.ofInstant(now, ZoneId.systemDefault()));
+            userRepository.save(u);
+        });
     }
 
     public Optional<Instant> getLastSeen(String username){
-        return Optional.of(LAST_SEEN.getOrDefault(username,null));
+        return Optional.ofNullable(LAST_SEEN.get(username));
     }
 }

--- a/src/main/java/in/lazygod/websocket/repositories/ChatMessageRepository.java
+++ b/src/main/java/in/lazygod/websocket/repositories/ChatMessageRepository.java
@@ -10,5 +10,8 @@ import java.util.List;
 public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
     List<ChatMessage> findByToAndDeliveredFalse(String to);
 
-    List<ChatMessage> findByConvsationIdAndBeforeTimestamp(String conversationId, Instant instant, PageRequest timestamp);
+    List<ChatMessage> findByConversationIdAndTimestampBeforeOrderByTimestampDesc(
+            String conversationId,
+            Instant before,
+            PageRequest pageable);
 }

--- a/src/main/java/in/lazygod/websocket/service/ChatService.java
+++ b/src/main/java/in/lazygod/websocket/service/ChatService.java
@@ -14,7 +14,6 @@ import in.lazygod.websocket.repositories.ChatMessageRepository;
 import in.lazygod.cluster.ClusterService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -130,7 +129,9 @@ public class ChatService {
 
         String conversationId = conversationId(reciptiant.getUsername(),user.getUsername());
 
-        return repository.findByConvsationIdAndBeforeTimestamp(conversationId,Instant.ofEpochMilli(timestamp),
-                PageRequest.of(0,size, Sort.by(Sort.Direction.DESC,"timestamp")));
+        return repository.findByConversationIdAndTimestampBeforeOrderByTimestampDesc(
+                conversationId,
+                Instant.ofEpochMilli(timestamp),
+                PageRequest.of(0, size));
     }
 }


### PR DESCRIPTION
## Summary
- refine repository method name for paging chat history
- adjust chat service to use the correct repository query
- persist user last-seen timestamp and expose via manager
- display chat history and user presence in chat.js
- store current user info for chat

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688d6844e4948330b71ace8dcf45095c