### PR TITLE
Load invitations from database and add user search

### DIFF
--- a/src/main/java/in/lazygod/controller/ConnectionController.java
+++ b/src/main/java/in/lazygod/controller/ConnectionController.java
@@ -1,5 +1,6 @@
 package in.lazygod.controller;
 
+import in.lazygod.dto.ConnectionRequestResponse;
 import in.lazygod.models.Connection;
 import in.lazygod.service.ConnectionService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -33,7 +34,7 @@ public class ConnectionController {
     }
 
     @GetMapping("/pending")
-    public ResponseEntity<List<Connection>> pending() {
+    public ResponseEntity<List<ConnectionRequestResponse>> pending() {
         return ResponseEntity.ok(connectionService.pendingRequests());
     }
 }

--- a/src/main/java/in/lazygod/controller/UserController.java
+++ b/src/main/java/in/lazygod/controller/UserController.java
@@ -25,6 +25,11 @@ public class UserController {
         return ResponseEntity.ok(SecurityContextHolderUtil.getCurrentUser());
     }
 
+    @GetMapping("/search")
+    public ResponseEntity<List<User>> search(@RequestParam("q") String q) {
+        return ResponseEntity.ok(userService.searchUsers(q));
+    }
+
     @GetMapping("/connected")
     public ResponseEntity<List<User>> request(
             @RequestParam(required = false, defaultValue = "0") Integer page,

--- a/src/main/java/in/lazygod/dto/ConnectionRequestResponse.java
+++ b/src/main/java/in/lazygod/dto/ConnectionRequestResponse.java
@@ -1,0 +1,14 @@
+package in.lazygod.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConnectionRequestResponse {
+    private String connectionId;
+    private String username;
+    private String fullName;
+}

--- a/src/main/java/in/lazygod/repositories/UserRepository.java
+++ b/src/main/java/in/lazygod/repositories/UserRepository.java
@@ -1,11 +1,15 @@
 package in.lazygod.repositories;
 
 import in.lazygod.models.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, String> {
 
     Optional<User> findByUsername(String username);
+
+    List<User> findByUsernameContainingIgnoreCase(String username, Pageable pageable);
 }

--- a/src/main/java/in/lazygod/service/ConnectionService.java
+++ b/src/main/java/in/lazygod/service/ConnectionService.java
@@ -1,6 +1,8 @@
 package in.lazygod.service;
 
+import in.lazygod.dto.ConnectionRequestResponse;
 import in.lazygod.enums.ConnectionStatus;
+import in.lazygod.exception.NotFoundException;
 import in.lazygod.models.Connection;
 import in.lazygod.models.User;
 import in.lazygod.repositories.ConnectionRepository;
@@ -27,7 +29,7 @@ public class ConnectionService {
     public Connection sendRequest(String username) {
         User from = SecurityContextHolderUtil.getCurrentUser();
         User to = userRepository.findByUsername(username)
-                .orElseThrow(() -> new in.lazygod.exception.NotFoundException("user.not.found"));
+                .orElseThrow(() -> new NotFoundException("user.not.found"));
 
         connectionRepository.findByFromUserIdAndToUserId(from.getUserId(), to.getUserId())
                 .ifPresent(c -> {
@@ -55,7 +57,7 @@ public class ConnectionService {
     public Connection acceptRequest(String connectionId) {
         User current = SecurityContextHolderUtil.getCurrentUser();
         Connection connection = connectionRepository.findById(connectionId)
-                .orElseThrow(() -> new in.lazygod.exception.NotFoundException("connection.not.found"));
+                .orElseThrow(() -> new NotFoundException("connection.not.found"));
 
         if (!connection.getToUserId().equals(current.getUserId())) {
             throw new in.lazygod.exception.ForbiddenException("not.authorized");
@@ -77,7 +79,7 @@ public class ConnectionService {
     public Connection rejectRequest(String connectionId) {
         User current = SecurityContextHolderUtil.getCurrentUser();
         Connection connection = connectionRepository.findById(connectionId)
-                .orElseThrow(() -> new in.lazygod.exception.NotFoundException("connection.not.found"));
+                .orElseThrow(() -> new NotFoundException("connection.not.found"));
 
         if (!connection.getToUserId().equals(current.getUserId())) {
             throw new in.lazygod.exception.ForbiddenException("not.authorized");
@@ -95,8 +97,13 @@ public class ConnectionService {
         return connection;
     }
 
-    public List<Connection> pendingRequests() {
+    public List<ConnectionRequestResponse> pendingRequests() {
         User current = SecurityContextHolderUtil.getCurrentUser();
-        return connectionRepository.findByToUserIdAndStatus(current.getUserId(), ConnectionStatus.PENDING);
+        List<Connection> connections = connectionRepository.findByToUserIdAndStatus(current.getUserId(), ConnectionStatus.PENDING);
+        return connections.stream().map(c -> {
+            User from = userRepository.findById(c.getFromUserId())
+                    .orElseThrow(() -> new NotFoundException("user.not.found"));
+            return new ConnectionRequestResponse(c.getConnectionId(), from.getUsername(), from.getFullName());
+        }).toList();
     }
 }

--- a/src/main/java/in/lazygod/service/UserService.java
+++ b/src/main/java/in/lazygod/service/UserService.java
@@ -64,6 +64,15 @@ public class UserService {
         return true;
     }
 
+    public List<User> searchUsers(String query) {
+        User current = SecurityContextHolderUtil.getCurrentUser();
+        return userRepository
+                .findByUsernameContainingIgnoreCase(query, PageRequest.of(0, 5))
+                .stream()
+                .filter(u -> !u.getUserId().equals(current.getUserId()))
+                .toList();
+    }
+
     @CacheEvict(value = "user-details", key = "T(in.lazygod.security.SecurityContextHolderUtil).getCurrentUser().getUsername()")
     public User updateProfile(UserUpdateRequest request) {
         User current = SecurityContextHolderUtil.getCurrentUser();

--- a/src/main/resources/templates/invitations.html
+++ b/src/main/resources/templates/invitations.html
@@ -42,26 +42,83 @@
 <body>
 <div id="main">
     <h2>Send Invitation</h2>
-    <form>
-        <input type="text" placeholder="Username or email" />
+    <form id="invitationForm">
+        <input id="searchInput" type="text" placeholder="Username" list="userSuggestions" />
+        <datalist id="userSuggestions"></datalist>
         <button type="submit">Send</button>
     </form>
 
     <h2>Incoming Invitations</h2>
-    <ul>
-        <li>John Doe
-            <span class="actions">
-                <button>Accept</button>
-                <button>Reject</button>
-            </span>
-        </li>
-        <li>Jane Smith
-            <span class="actions">
-                <button>Accept</button>
-                <button>Reject</button>
-            </span>
-        </li>
-    </ul>
+    <ul id="invitationList"></ul>
 </div>
+<script>
+    function authHeaders() {
+        const token = localStorage.getItem('accessToken');
+        return token ? { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json' } : { 'Content-Type': 'application/json' };
+    }
+
+    function loadInvitations() {
+        fetch('/connections/pending', { headers: authHeaders() })
+            .then(resp => resp.json())
+            .then(data => {
+                const list = document.getElementById('invitationList');
+                list.innerHTML = '';
+                data.forEach(inv => {
+                    const li = document.createElement('li');
+                    li.textContent = inv.fullName || inv.username;
+                    const actions = document.createElement('span');
+                    actions.className = 'actions';
+                    const acceptBtn = document.createElement('button');
+                    acceptBtn.textContent = 'Accept';
+                    acceptBtn.onclick = () => respond(inv.connectionId, 'accept');
+                    const rejectBtn = document.createElement('button');
+                    rejectBtn.textContent = 'Reject';
+                    rejectBtn.onclick = () => respond(inv.connectionId, 'reject');
+                    actions.appendChild(acceptBtn);
+                    actions.appendChild(rejectBtn);
+                    li.appendChild(actions);
+                    list.appendChild(li);
+                });
+            });
+    }
+
+    function respond(id, action) {
+        fetch(`/connections/${id}/${action}`, { method: 'POST', headers: authHeaders() })
+            .then(() => loadInvitations());
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        loadInvitations();
+        const input = document.getElementById('searchInput');
+        const suggestions = document.getElementById('userSuggestions');
+
+        input.addEventListener('input', () => {
+            const q = input.value.trim();
+            if (!q) { suggestions.innerHTML = ''; return; }
+            fetch(`/users/search?q=${encodeURIComponent(q)}`, { headers: authHeaders() })
+                .then(r => r.json())
+                .then(users => {
+                    suggestions.innerHTML = '';
+                    users.forEach(u => {
+                        const opt = document.createElement('option');
+                        opt.value = u.username;
+                        suggestions.appendChild(opt);
+                    });
+                });
+        });
+
+        document.getElementById('invitationForm').addEventListener('submit', e => {
+            e.preventDefault();
+            const username = input.value.trim();
+            if (!username) return;
+            fetch(`/connections/request/${encodeURIComponent(username)}`, { method: 'POST', headers: authHeaders() })
+                .then(() => {
+                    input.value = '';
+                    suggestions.innerHTML = '';
+                    loadInvitations();
+                });
+        });
+    });
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Load incoming invitations from database via new DTO and service logic
- Add user search endpoint for inviting new connections
- Wire invitations page to call search and pending requests APIs

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_688e4cf7698c8330a2bf5639ee64f09a