### PR TITLE
feat(chat): show notifications for messages in other chats

### DIFF
--- a/src/main/resources/static/js/chat.js
+++ b/src/main/resources/static/js/chat.js
@@ -57,7 +57,16 @@ function connectWs() {
   ws.onmessage = e => {
     const pkt = JSON.parse(e.data);
     if (pkt.type === 'chat') {
-      showMessage(pkt.from, pkt.payload.text, pkt.payload.id, Date.now());
+      if (pkt.from === currentChat) {
+        showMessage(pkt.from, pkt.payload.text, pkt.payload.id, Date.now());
+      } else {
+        const userItem = document.querySelector(`#users .user[data-username="${pkt.from}"]`);
+        if (userItem) {
+          userItem.classList.add('unread');
+          const lastMsgEl = userItem.querySelector('.last-msg');
+          if (lastMsgEl) lastMsgEl.textContent = pkt.payload.text;
+        }
+      }
     } else if (pkt.type === 'receipt') {
       const el = document.getElementById('msg-' + pkt.payload.id);
       if (el) el.querySelector('.status').textContent = pkt.payload.status;
@@ -129,6 +138,8 @@ const enriched = await Promise.all(users.map(async u => {
         document.getElementById('messages').innerHTML = '';
         document.getElementById('chatWith').textContent = u.username;
         document.getElementById('userStatus').textContent = '';
+
+        btn.classList.remove('unread');
 
         // Set active class
         document.querySelectorAll('#users .user').forEach(el => el.classList.remove('active'));

--- a/src/main/resources/templates/chat.html
+++ b/src/main/resources/templates/chat.html
@@ -45,6 +45,15 @@
             background-color: #f1f3f5;
         }
 
+        .user.unread {
+            background-color: #e7f1ff;
+        }
+
+        .user.unread .name,
+        .user.unread .last-msg {
+            font-weight: 600;
+        }
+
         .user-pic {
             width: 36px;
             height: 36px;


### PR DESCRIPTION
## Summary
- only display messages from currently open chat
- highlight sidebar entries when new messages arrive

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e534ef05083308246c9e65b055be2