### PR TITLE
Remove chat placeholders and auto-open latest conversation

### DIFF
--- a/src/main/resources/static/js/chat.js
+++ b/src/main/resources/static/js/chat.js
@@ -140,6 +140,13 @@ const enriched = await Promise.all(users.map(async u => {
       list.appendChild(btn);
       requestLastSeen(u.username);
     });
+    if (enriched.length > 0) {
+      const first = list.querySelector('.user');
+      if (first) first.click();
+    } else {
+      document.getElementById('chatWith').textContent = '';
+      document.getElementById('userStatus').textContent = '';
+    }
   } catch (e) {
     console.error(e);
   }

--- a/src/main/resources/templates/chat.html
+++ b/src/main/resources/templates/chat.html
@@ -219,42 +219,14 @@
 </head>
 <body>
 <div id="main">
-    <div id="users">
-        <div class="user active">
-            <div class="user-pic">A</div>
-            <div class="user-info">
-                <div class="name">Alice</div>
-                <div class="status-text">online</div>
-                <div class="last-msg">Hey there</div>
-            </div>
-            <div class="status-dot online"></div>
-        </div>
-        <div class="user">
-            <div class="user-pic">B</div>
-            <div class="user-info">
-                <div class="name">Bob</div>
-                <div class="status-text">last seen 1h ago</div>
-                <div class="last-msg">See you!</div>
-            </div>
-            <div class="status-dot offline"></div>
-        </div>
-    </div>
+    <div id="users"></div>
 
     <div id="chat">
         <div id="chat-header">
-            <div id="chatWith">Chat with Alice</div>
-            <div id="userStatus" class="user-status">online</div>
+            <div id="chatWith"></div>
+            <div id="userStatus" class="user-status"></div>
         </div>
-        <div id="messages">
-            <div class="msg-wrapper">
-                <div class="msg-profile">A</div>
-                <div class="msg">Hi there! How are you?</div>
-            </div>
-            <div class="msg-wrapper me">
-                <div class="msg">I'm good, thanks!</div>
-                <div class="msg-profile">M</div>
-            </div>
-        </div>
+        <div id="messages"></div>
         <div id="input">
             <input id="messageText" type="text" placeholder="Type a message..." />
             <button id="sendBtn">Send</button>


### PR DESCRIPTION
## Summary
- remove hardcoded chat and user placeholders from chat template
- automatically open latest user conversation or leave chat blank when none

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e54415e0c8330b7c57ea9c0751ab2