### PR TITLE
Ensure WebRTC offer sent when websocket already open

### DIFF
--- a/src/main/resources/static/js/call.js
+++ b/src/main/resources/static/js/call.js
@@ -106,16 +106,22 @@ async function init() {
     }
   };
 
-  ws.onopen = async () => {
-    if (initiate) {
-      const offer = await pc.createOffer();
-      await pc.setLocalDescription(offer);
-      ws.send(JSON.stringify({
-        type: 'call',
-        payload: { to: remoteUser, type: 'offer', offer }
-      }));
-    }
+  const sendOffer = async () => {
+    const offer = await pc.createOffer();
+    await pc.setLocalDescription(offer);
+    ws.send(JSON.stringify({
+      type: 'call',
+      payload: { to: remoteUser, type: 'offer', offer }
+    }));
   };
+
+  if (initiate) {
+    if (ws.readyState === WebSocket.OPEN) {
+      await sendOffer();
+    } else {
+      ws.addEventListener('open', sendOffer);
+    }
+  }
 
   document.getElementById('hangupBtn').addEventListener('click', () => {
     if (ws && ws.readyState === WebSocket.OPEN) {


### PR DESCRIPTION
## Summary
- fix race where quick websocket connections skipped sending offer

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e6fb24d24833094e10706ac7b51b9