### PR TITLE
Improve call feature UI with draggable overlay

### DIFF
--- a/src/main/resources/static/css/dashboard.css
+++ b/src/main/resources/static/css/dashboard.css
@@ -59,8 +59,8 @@
   #callOverlay {
     width: 100vw !important;
     height: 100vh !important;
-    bottom: 0;
-    right: 0;
+    top: 0;
+    left: 0;
     border-radius: 0;
   }
 

--- a/src/main/resources/static/js/call.js
+++ b/src/main/resources/static/js/call.js
@@ -21,12 +21,17 @@ function createUi() {
   overlay.id = 'callOverlay';
   overlay.style.display = 'none';
   overlay.style.position = 'fixed';
-  overlay.style.bottom = '10px';
-  overlay.style.right = '10px';
+  overlay.style.top = '10px';
+  overlay.style.left = '10px';
   overlay.style.width = '240px';
   overlay.style.height = '180px';
   overlay.style.background = '#000';
   overlay.style.zIndex = '1000';
+  overlay.style.borderRadius = '8px';
+  overlay.style.boxShadow = '0 2px 8px rgba(0,0,0,0.3)';
+  overlay.style.resize = 'both';
+  overlay.style.overflow = 'hidden';
+  overlay.style.cursor = 'move';
 
   const remoteVideo = document.createElement('video');
   remoteVideo.id = 'remoteVideo';
@@ -47,10 +52,18 @@ function createUi() {
   overlay.appendChild(localVideo);
 
   const endBtn = document.createElement('button');
-  endBtn.textContent = '✖';
+  endBtn.innerHTML = '📴';
+  endBtn.title = 'End Call';
   endBtn.style.position = 'absolute';
   endBtn.style.top = '5px';
   endBtn.style.right = '5px';
+  endBtn.style.background = '#dc3545';
+  endBtn.style.color = '#fff';
+  endBtn.style.border = 'none';
+  endBtn.style.borderRadius = '50%';
+  endBtn.style.width = '32px';
+  endBtn.style.height = '32px';
+  endBtn.style.cursor = 'pointer';
   endBtn.addEventListener('click', endCall);
   overlay.appendChild(endBtn);
   const controls = document.createElement('div');
@@ -83,6 +96,30 @@ function createUi() {
 
   document.body.appendChild(overlay);
 
+  let isDragging = false;
+  let dragOffsetX = 0;
+  let dragOffsetY = 0;
+  overlay.addEventListener('mousedown', e => {
+    if (e.target.tagName === 'BUTTON') return;
+    isDragging = true;
+    dragOffsetX = e.clientX - overlay.offsetLeft;
+    dragOffsetY = e.clientY - overlay.offsetTop;
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', stopDrag);
+  });
+
+  function onMouseMove(e) {
+    if (!isDragging) return;
+    overlay.style.left = `${e.clientX - dragOffsetX}px`;
+    overlay.style.top = `${e.clientY - dragOffsetY}px`;
+  }
+
+  function stopDrag() {
+    isDragging = false;
+    document.removeEventListener('mousemove', onMouseMove);
+    document.removeEventListener('mouseup', stopDrag);
+  }
+
   const incoming = document.createElement('div');
   incoming.id = 'incomingCall';
   incoming.style.display = 'none';
@@ -98,8 +135,8 @@ function createUi() {
       <span id="callerName"></span> is calling...
     </div>
     <div style="display: flex; justify-content: center; gap: 10px;">
-      <button id="acceptCall" style="background: #28a745; color: white; padding: 8px 12px; border-radius: 6px;">✅ Accept</button>
-      <button id="declineCall" style="background: #dc3545; color: white; padding: 8px 12px; border-radius: 6px;">❌ Decline</button>
+      <button id="acceptCall" title="Accept" style="background:#28a745;color:white;border:none;border-radius:50%;width:40px;height:40px;cursor:pointer;">📞</button>
+      <button id="declineCall" title="Decline" style="background:#dc3545;color:white;border:none;border-radius:50%;width:40px;height:40px;cursor:pointer;">✖</button>
     </div>`;
 
   document.body.appendChild(incoming);

--- a/src/main/resources/templates/chat.html
+++ b/src/main/resources/templates/chat.html
@@ -213,6 +213,19 @@
             background-color: rgba(0, 0, 0, 0.2);
             border-radius: 3px;
         }
+        .call-button {
+            background-color: #28a745;
+            color: #fff;
+            border: none;
+            width: 40px;
+            height: 40px;
+            border-radius: 50%;
+            font-size: 1.2em;
+            cursor: pointer;
+        }
+        .call-button:hover {
+            background-color: #218838;
+        }
         .msg .meta {
             display: flex;
             justify-content: flex-end;
@@ -234,7 +247,7 @@
         <div id="chat-header">
             <div id="chatWith"></div>
             <div id="userStatus" class="user-status"></div>
-            <button id="callBtn" style="background-color: #007bff; color: white; border: none; padding: 8px 16px; border-radius: 20px; cursor: pointer;">📞 Call</button>
+            <button id="callBtn" class="call-button" title="Start Call">📞</button>
 
         </div>
         <div id="messages"></div>


### PR DESCRIPTION
## Summary
- style call interface with rounded, resizable frame and drag support
- replace accept/decline and hang-up buttons with concise icon versions
- refresh chat call button to a compact circular design

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688faf3ca86883309de03b883454a9d5