### PR TITLE
Add Lingva-based document translation endpoint and UI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,12 @@ services:
     volumes:
       - redis_data:/data
 
+  lingva:
+    image: hectorm/lingva-translate:latest
+    restart: always
+    ports:
+      - "3000:3000"
+
   etherpad:
     image: etherpad/etherpad
     restart: always

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,18 @@
             <artifactId>spring-boot-starter-cache</artifactId>
         </dependency>
 
+        <!-- Translation utilities -->
+        <dependency>
+            <groupId>com.ibm.icu</groupId>
+            <artifactId>icu4j</artifactId>
+            <version>74.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>5.2.5</version>
+        </dependency>
+
         <!-- Dev Tools -->
         <!--
         <dependency>

--- a/src/main/java/in/lazygod/controller/TranslationController.java
+++ b/src/main/java/in/lazygod/controller/TranslationController.java
@@ -1,0 +1,50 @@
+package in.lazygod.controller;
+
+import in.lazygod.translate.docx.DocxTranslator;
+import in.lazygod.translate.txt.TxtTranslator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.IOException;
+import java.util.Locale;
+
+@RestController
+@RequiredArgsConstructor
+public class TranslationController {
+
+    private final TxtTranslator txtTranslator;
+    private final DocxTranslator docxTranslator;
+
+    @PostMapping(value = "/translate", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<byte[]> translate(@RequestParam("file") MultipartFile file,
+                                            @RequestParam String targetLang,
+                                            @RequestParam(required = false) String sourceLang) throws IOException {
+        String name = file.getOriginalFilename();
+        String ext = (name != null && name.contains(".")) ? name.substring(name.lastIndexOf('.') + 1) : "";
+        Locale locale = Locale.forLanguageTag(sourceLang == null ? "en" : sourceLang);
+        byte[] out;
+        MediaType mediaType;
+        switch (ext.toLowerCase()) {
+            case "txt" -> {
+                out = txtTranslator.translate(file.getBytes(), sourceLang, targetLang, locale);
+                mediaType = MediaType.TEXT_PLAIN;
+            }
+            case "docx" -> {
+                out = docxTranslator.translate(file.getBytes(), sourceLang, targetLang, locale);
+                mediaType = MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+            }
+            default -> throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unsupported file type");
+        }
+        String outName = "translated_" + (name == null ? "out" : name);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + outName)
+                .contentType(mediaType)
+                .body(out);
+    }
+}

--- a/src/main/java/in/lazygod/translate/LingvaTranslationService.java
+++ b/src/main/java/in/lazygod/translate/LingvaTranslationService.java
@@ -1,0 +1,41 @@
+package in.lazygod.translate;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@Service
+public class LingvaTranslationService implements TranslationService {
+
+    private final RestTemplate restTemplate;
+    private final String baseUrl;
+
+    public LingvaTranslationService(RestTemplateBuilder builder,
+                                    @Value("${lingva.base-url:http://lingva:3000}") String baseUrl) {
+        this.restTemplate = builder.build();
+        this.baseUrl = baseUrl;
+    }
+
+    @Override
+    public List<String> translateBatch(List<String> segments, String src, String tgt) {
+        return segments.stream().map(s -> translate(s, src, tgt)).toList();
+    }
+
+    private String translate(String text, String src, String tgt) {
+        String path = String.format("/api/v1/%s/%s/%s",
+                (src == null || src.isBlank()) ? "auto" : src,
+                tgt,
+                UriUtils.encodePathSegment(text, StandardCharsets.UTF_8));
+        TranslationResponse response = restTemplate.getForObject(baseUrl + path, TranslationResponse.class);
+        return response != null ? response.translation : text;
+    }
+
+    public static class TranslationResponse {
+        public String translation;
+    }
+}

--- a/src/main/java/in/lazygod/translate/Masker.java
+++ b/src/main/java/in/lazygod/translate/Masker.java
@@ -1,0 +1,45 @@
+package in.lazygod.translate;
+
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class Masker {
+    private static final Pattern URL = Pattern.compile("(https?://\\S+)");
+    private static final Pattern VAR = Pattern.compile("(\\$\\{[^}]+}|%\\w|\\{[^}]+})");
+
+    public MaskResult mask(String input) {
+        Map<String, String> map = new LinkedHashMap<>();
+        String out = input;
+        out = replace(out, URL, map, "URL");
+        out = replace(out, VAR, map, "VAR");
+        return new MaskResult(out, map);
+    }
+
+    public String unmask(String translated, Map<String, String> map) {
+        for (var e : map.entrySet()) {
+            translated = translated.replace(e.getKey(), e.getValue());
+        }
+        return translated;
+    }
+
+    private String replace(String s, Pattern p, Map<String, String> map, String tag) {
+        Matcher m = p.matcher(s);
+        StringBuffer sb = new StringBuffer();
+        int i = 0;
+        while (m.find()) {
+            String token = "⟦" + tag + i + "⟧";
+            i++;
+            map.put(token, m.group(1));
+            m.appendReplacement(sb, Matcher.quoteReplacement(token));
+        }
+        m.appendTail(sb);
+        return sb.toString();
+    }
+
+    public record MaskResult(String text, Map<String, String> dict) {}
+}

--- a/src/main/java/in/lazygod/translate/Segmenter.java
+++ b/src/main/java/in/lazygod/translate/Segmenter.java
@@ -1,0 +1,22 @@
+package in.lazygod.translate;
+
+import com.ibm.icu.text.BreakIterator;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+@Component
+public class Segmenter {
+    public List<String> sentences(String text, Locale locale) {
+        BreakIterator bi = BreakIterator.getSentenceInstance(locale);
+        bi.setText(text);
+        List<String> out = new ArrayList<>();
+        int start = bi.first();
+        for (int end = bi.next(); end != BreakIterator.DONE; start = end, end = bi.next()) {
+            out.add(text.substring(start, end));
+        }
+        return out;
+    }
+}

--- a/src/main/java/in/lazygod/translate/TranslationService.java
+++ b/src/main/java/in/lazygod/translate/TranslationService.java
@@ -1,0 +1,7 @@
+package in.lazygod.translate;
+
+import java.util.List;
+
+public interface TranslationService {
+    List<String> translateBatch(List<String> segments, String src, String tgt);
+}

--- a/src/main/java/in/lazygod/translate/docx/DocxTranslator.java
+++ b/src/main/java/in/lazygod/translate/docx/DocxTranslator.java
@@ -1,0 +1,56 @@
+package in.lazygod.translate.docx;
+
+import in.lazygod.translate.Masker;
+import in.lazygod.translate.Segmenter;
+import in.lazygod.translate.TranslationService;
+import org.apache.poi.xwpf.usermodel.*;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+@Service
+public class DocxTranslator {
+    private final Segmenter segmenter;
+    private final Masker masker;
+    private final TranslationService ts;
+
+    public DocxTranslator(Segmenter segmenter, Masker masker, TranslationService ts) {
+        this.segmenter = segmenter;
+        this.masker = masker;
+        this.ts = ts;
+    }
+
+    public byte[] translate(byte[] docx, String src, String tgt, Locale locale) throws IOException {
+        try (var is = new ByteArrayInputStream(docx);
+             var doc = new XWPFDocument(is);
+             var os = new ByteArrayOutputStream()) {
+
+            for (XWPFParagraph p : doc.getParagraphs()) {
+                String logical = p.getText();
+                if (logical == null || logical.isBlank()) continue;
+
+                var mr = masker.mask(logical);
+                List<String> segs = segmenter.sentences(mr.text(), locale);
+                List<String> outSegs = ts.translateBatch(segs, src, tgt);
+                String translated = masker.unmask(String.join("", outSegs), mr.dict());
+
+                clearRuns(p);
+                XWPFRun r = p.createRun();
+                r.setText(translated, 0);
+            }
+            doc.write(os);
+            return os.toByteArray();
+        }
+    }
+
+    private void clearRuns(XWPFParagraph p) {
+        for (int i = p.getRuns().size() - 1; i >= 0; i--) {
+            p.removeRun(i);
+        }
+    }
+}

--- a/src/main/java/in/lazygod/translate/txt/TxtTranslator.java
+++ b/src/main/java/in/lazygod/translate/txt/TxtTranslator.java
@@ -1,0 +1,34 @@
+package in.lazygod.translate.txt;
+
+import in.lazygod.translate.Masker;
+import in.lazygod.translate.Segmenter;
+import in.lazygod.translate.TranslationService;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Locale;
+
+@Service
+public class TxtTranslator {
+    private final Segmenter segmenter;
+    private final Masker masker;
+    private final TranslationService ts;
+
+    public TxtTranslator(Segmenter segmenter, Masker masker, TranslationService ts) {
+        this.segmenter = segmenter;
+        this.masker = masker;
+        this.ts = ts;
+    }
+
+    public byte[] translate(byte[] bytes, String src, String tgt, Locale locale) throws IOException {
+        String text = new String(bytes, StandardCharsets.UTF_8);
+        var mr = masker.mask(text);
+        List<String> segs = segmenter.sentences(mr.text(), locale);
+        List<String> outSegs = ts.translateBatch(segs, src, tgt);
+        String joined = String.join("", outSegs);
+        String finalText = masker.unmask(joined, mr.dict());
+        return finalText.getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/in/lazygod/web/WebAppController.java
+++ b/src/main/java/in/lazygod/web/WebAppController.java
@@ -36,4 +36,9 @@ public class WebAppController {
         return "drive";
 
     }
+
+    @GetMapping("/translate")
+    public String translatePage() {
+        return "translate";
+    }
 }

--- a/src/main/resources/static/js/translate.js
+++ b/src/main/resources/static/js/translate.js
@@ -1,0 +1,25 @@
+document.getElementById('translateForm').addEventListener('submit', async function (e) {
+    e.preventDefault();
+    const fileInput = document.getElementById('file');
+    const targetLang = document.getElementById('targetLang').value;
+    if (!fileInput.files.length) return;
+    const formData = new FormData();
+    formData.append('file', fileInput.files[0]);
+    formData.append('targetLang', targetLang);
+    document.getElementById('loading').style.display = 'block';
+    const res = await fetch('/translate', {
+        method: 'POST',
+        body: formData
+    });
+    document.getElementById('loading').style.display = 'none';
+    if (res.ok) {
+        const blob = await res.blob();
+        const url = window.URL.createObjectURL(blob);
+        const link = document.getElementById('downloadLink');
+        link.href = url;
+        link.download = 'translated_' + fileInput.files[0].name;
+        document.getElementById('result').style.display = 'block';
+    } else {
+        alert('Translation failed');
+    }
+});

--- a/src/main/resources/templates/translate.html
+++ b/src/main/resources/templates/translate.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <title>Translate Document</title>
+    <style>
+        body {font-family: Arial, sans-serif; margin: 40px;}
+        #loading {display:none;}
+        #result {display:none; margin-top:20px;}
+    </style>
+</head>
+<body>
+<h2>Translate Document</h2>
+<form id="translateForm">
+    <input type="file" id="file" name="file" required />
+    <input type="text" id="targetLang" name="targetLang" placeholder="Target language (e.g. fr)" required />
+    <button type="submit">Translate</button>
+</form>
+<div id="loading">Translating...</div>
+<div id="result">
+    <a id="downloadLink">Download translated file</a>
+</div>
+<script src="/js/translate.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- run Lingva Translate alongside app and expose translation endpoint
- integrate ICU4J and Apache POI utilities for file translation
- simple web page to upload a document, wait for translation, and download result

## Testing
- `mvn -q -e package -DskipTests` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ba79cc1ec8330860c9327eff57c48